### PR TITLE
Improved streaming procedure by passing existing input and output stream 

### DIFF
--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -259,13 +259,16 @@ function FfmpegProcessor(source) {
         } else {
           var args = self._buildFfmpegArgs(false);
         
-          // start conversion of file using spawn
-          var ffmpegProc = spawn('ffmpeg', args);
-          
+          // init ffmpeg procedure, depending on whether we have an input stream we will set the input stream as stdin instead of creating a new stream
+          var ffmpegProc;
           if (self.options.inputstream) {
-            // pump input stream to stdin
             self.options.inputstream.resume();
-            self.options.inputstream.pipe(ffmpegProc.stdin, { end: true });
+            ffmpegProc = spawn('ffmpeg', args, {
+              customFds: [self.options.inputstream, -1, -1];
+            });
+          }
+          else {
+            ffmpegProc = spawn('ffmpeg', args);
           }
           
           var stdout = '';
@@ -318,17 +321,19 @@ function FfmpegProcessor(source) {
           // write data to stdout
           args.push('pipe:1');
           
-          // start conversion of file using spawn
-          var ffmpegProc = spawn('ffmpeg', args);
-          
+          // init ffmpeg procedure, depending on whether we have an input stream we will set the input stream as stdin and output stream to the given stream
+          var ffmpegProc;
           if (self.options.inputstream) {
-            // pump input stream to stdin
             self.options.inputstream.resume();
-            self.options.inputstream.pipe(ffmpegProc.stdin);
+            ffmpegProc = spawn('ffmpeg', args, {
+              customFds: [self.options.inputstream, stream, -1];
+            });
+          }
+          else {
+            ffmpegProc = spawn('ffmpeg', args);
           }
           
           var stderr = '';
-          
           ffmpegProc.stderr.on('data', function(data) {
             stderr += data;
           });
@@ -336,9 +341,6 @@ function FfmpegProcessor(source) {
           ffmpegProc.on('exit', function(code) {
             callback(code, stderr);
           });
-          
-          // pipe stdout to stream
-          ffmpegProc.stdout.pipe(stream);
         }
       });      
     } catch(err) {


### PR DESCRIPTION
Improved streaming procedure by passing existing input and output stream to child process instead of creating new streams.

This should be much better, but please test and validate my changes before applying them (I have not had the chance yet, but it should work great.)
