### PR TITLE
added optional processing timeout parameter

### DIFF
--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -4,7 +4,7 @@ var fs = require('fs'),
   exec = require('child_process').exec,
   spawn = require('child_process').spawn;
 
-function FfmpegProcessor(source) {
+function FfmpegProcessor(source, timeout) { //timeout in milliseconds is optional
   // check if argument is a stream
   var srcstream, srcfile;
   if (typeof source === 'object') {
@@ -27,6 +27,7 @@ function FfmpegProcessor(source) {
     _useConstantVideoBitrate: false,
     inputfile: srcfile,
     inputstream: srcstream,
+    timeout: timeout,
     video: {},
     audio: {},
     additional: []
@@ -267,10 +268,20 @@ function FfmpegProcessor(source) {
             self.options.inputstream.resume();
             self.options.inputstream.pipe(ffmpegProc.stdin, { end: true });
           }
+
+          //handle timeout if set
+          var processTimer;
+          if (self.options.timeout) {
+            processTimer = setTimeout(function() {
+              ffmpegProc.kill('SIGKILL');
+              callback(-1, 'timeout');
+            }, self.options.timeout);
+          }
           
           var stdout = '';
           var stderr = '';
           ffmpegProc.on('exit', function(code) {
+            if (processTimer) clearTimeout(processTimer);
             // check if we have to run flvtool2 to update flash video meta data
             if (self.options._updateFlvMetadata === true) {
               // check if flvtool2 is installed
@@ -326,6 +337,15 @@ function FfmpegProcessor(source) {
             self.options.inputstream.resume();
             self.options.inputstream.pipe(ffmpegProc.stdin);
           }
+
+          //handle timeout if set
+          var processTimer;
+          if (self.options.timeout) {
+            processTimer = setTimeout(function() {
+              ffmpegProc.kill('SIGKILL');
+              callback(-1, 'timeout');
+            }, self.options.timeout);
+          }
           
           var stderr = '';
           
@@ -334,6 +354,7 @@ function FfmpegProcessor(source) {
           });
           
           ffmpegProc.on('exit', function(code) {
+            if (processTimer) clearTimeout(processTimer);
             callback(code, stderr);
           });
           


### PR DESCRIPTION
added optional processing timeout parameter, to make sure that ffmpeg never runs for longer than allowed (eg. to prevent unexpectedly long processing or process hanging).
