### PR TITLE
close http stream with end function, because it has not a filedescriptor 

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -119,7 +119,7 @@ exports = module.exports = function Processor(command) {
             if(/http/.exec(self.options.inputfile)) {
             	callback(code, stderr);
             } else {
-              fs.close(stream.fd, function() {
+              var cb_ = function() {
                 if (self.options.inputstream) {
                   fs.close(self.options.inputstream.fd, function() {
                     callback(code, stderr);
@@ -128,7 +128,13 @@ exports = module.exports = function Processor(command) {
                 else {
                   callback(code, stderr);
                 }
-              });
+              };
+              if ( !stream.fd ) {
+                stream.end ? stream.end() : callback(code, "stream will not be closed");
+                cb_();
+              } else {
+                fs.close(stream.fd, cb_);
+              }
             }
           });
         }


### PR DESCRIPTION
close http stream with end function, because it has not a filedescriptor property
