### PR TITLE
Rotate property in video metadata

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -30,7 +30,8 @@ var meta = module.exports = {
         var channels = /Audio: [\w]+, [0-9]+ Hz, ([a-z0-9:]+)[a-z0-9\/,]*/.exec(stderr);
         var audio_stream = /Stream #([0-9\.]+)([a-z0-9\(\)\[\]]*)[:] Audio/.exec(stderr);
         var is_synched = (/start: 0.000000/.exec(stderr) != null);
-
+        var rotate = /rotate[\s]+:[\s]([\d]{2,3})/.exec(stderr);
+        
         // build return object
         var ret = {
           durationraw: (duration && duration.length > 1) ? duration[1] : '',
@@ -44,6 +45,7 @@ var meta = module.exports = {
               w: (resolution && resolution.length > 2) ? parseInt(resolution[2]) : 0,
               h: (resolution && resolution.length > 3) ? parseInt(resolution[3]) : 0
             },
+            rotate: (rotate && rotate.length > 1) ? parseInt(rotate[1]) : 0,
             fps: (fps && fps.length > 1) ? parseFloat(fps[1]) : 0.0,
             stream: (video_stream && video_stream.length > 1) ? parseFloat(video_stream[1]) : 0.0
           },


### PR DESCRIPTION
Added rotate property to video metadata.  This is returned by ffmpeg when .mov movies have been captured by a device held at a different orientation then their hardware camera i.e. portrait mode rather than landscape or upside-down.  possible values are 90,180,270.  It signifies the amount of clockwise rotation required to return the movie to the proper orientation.
