### PR TITLE
Additional network streaming protocols.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -132,7 +132,7 @@ exports = module.exports = function Processor(command) {
             ffmpegProc.on('exit', function(code, signal) {
               if (processTimer) clearTimeout(processTimer);
               // close file descriptor on outstream
-              if(/^(http|mms|mmsh):\/\//.exec(self.options.inputfile)) {
+              if(/^[a-z]+:\/\//.exec(self.options.inputfile)) {
                 callback(code, stderr);
               } else {
                 var cb_ = function() {
@@ -342,7 +342,7 @@ exports = module.exports = function Processor(command) {
       try
       {
 		// Check if it's a network streaming url. 
-        if(/^(http|mms|mmsh):\/\//.exec(this.options.inputfile)) {
+        if(/^[a-z]+:\/\//.exec(this.options.inputfile)) {
           args.push('-i', this.options.inputfile.replace(' ', '%20'));
         } else {
           var fstats = fs.statSync(this.options.inputfile);


### PR DESCRIPTION
Adding support for other (mms, mmsh) network streaming protocols, increased accuracy of the regular expression

Without this, trying to add any network protocol that doesn't start with http (e.g. mms and mmsh) is treated as a file, thus failing as input for ffmpeg 
