### PR TITLE
Bug fix for issue #48

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,12 +1,3 @@
-Object.prototype.gcd = function(a, b) {
-  while (a != 0) {
-    var z = b % a;
-    b = a;
-    a = z;
-  }
-  return b;
-}
-
 String.prototype.toAspectRatio = function() {
   var p = this.split(':');
   if (p.length != 2) {

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -215,6 +215,14 @@ function FfmpegCommand(args) {
     this.options.onProgress = callback;
     return this;
   };
+  FfmpegCommand.prototype.gcd = function(a, b) {
+    while (a != 0) {
+      var z = b % a;
+      b = a;
+      a = z;
+    }
+    return b;
+  };
    
   // private methods
   FfmpegCommand.prototype._prepare = function(callback) {


### PR DESCRIPTION
Hi,

I`ve fixed issue #48 by moving the gcd function from the global Object variable to the prototype property of fluent-ffmpeg.js. This fixes the endless loop which it enters when you require() in some circumstances.

Greetings,

Jeroen
