### PR TITLE
fixed package.json reference to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = process.env.FLUENTFFMPEG_COV ? require('./lib-cov/fluent-ffmpeg') : require('./lib/fluent-ffmpeg');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,0 @@
-module.exports = process.env.FLUENTFFMPEG_COV ? require('../lib-cov/fluent-ffmpeg') : require('../lib/fluent-ffmpeg');


### PR DESCRIPTION
Hey, first thanks for a great module.  I just upgraded to 1.1.0 and the package.json file changed from './lib/fluent-ffmpeg' to 'index', yet there was no index at the root directory.  This caused the module to break upon 'require("fluent-ffmpeg")'.  I figured I'd lift the index.js from lib to the root, as it referenced '../lib-cov' and '../lib', and your reference to it in the package.json reflected it should be at the root.
