### PR TITLE
Adds -r options for input and output fps

### DIFF
--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -115,6 +115,14 @@ function FfmpegCommand(args) {
     this.options.video.fps = fps;
     return this;
   };
+  FfmpegCommand.prototype.withFpsInput = function(fps) {
+    this.options.video.fpsInput = fps;
+    return this;
+  };
+  FfmpegCommand.prototype.withFpsOutput = function(fps) {
+    this.options.video.fpsOutput = fps;
+    return this;
+  };
   FfmpegCommand.prototype.withAspect = function(aspectRatio) {
     this.options.video.aspect = aspectRatio;
     return this;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -441,6 +441,10 @@ exports = module.exports = function Processor(command) {
 
     // add input file (if using fs mode)
     if (this.options.inputfile && !this.options.inputstream) {
+      // add input file fps
+      if (this.options.video.fpsInput) {
+        args.push('-r', this.options.video.fpsInput);
+      }
       if (/^[a-z]+:\/\//.exec(this.options.inputfile)) {
         args.push('-i', this.options.inputfile.replace(' ', '%20'));
       } else {
@@ -549,6 +553,10 @@ exports = module.exports = function Processor(command) {
       args.push('-s', this.options.video.size);
     }
 
+    // add output file fps
+    if (this.options.video.fpsOutput) {
+      args.push('-r', this.options.video.fpsOutput);
+    }
 
     if (this.options.outputfile) {
       args.push('-y', this.options.outputfile.replace(' ', '\\ '));


### PR DESCRIPTION
Setting the input and output FPS parameters have to come at the beginning and ends of the parameter list.  This allows that to happen.
