### PR TITLE
onProgress event occasionally fails

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -366,7 +366,10 @@ exports = module.exports = function Processor(command) {
     // get last stderr line
     var lastLine = stderrString.split(/\r\n|\r|\n/g);
     var ll = lastLine[lastLine.length - 2];
-    var progress = ll.split(/frame=([0-9\s]+)fps=([0-9\s]+)q=([0-9\.\s]+)(L?)size=([0-9\s]+)kB time=(([0-9]{2}):([0-9]{2}):([0-9]{2}).([0-9]{2})) bitrate=([0-9\.\s]+)kbits/ig);
+    var progress;
+    if (ll) {
+      progress = ll.split(/frame=([0-9\s]+)fps=([0-9\s]+)q=([0-9\.\s]+)(L?)size=([0-9\s]+)kB time=(([0-9]{2}):([0-9]{2}):([0-9]{2}).([0-9]{2})) bitrate=([0-9\.\s]+)kbits/ig);    
+    }
     if (progress && progress.length > 10) {
       // build progress report object
       var ret = {


### PR DESCRIPTION
Hi, on v1.2.0 the onProgress event occasionally fails running locally with the following error:

/node_modules/fluent-ffmpeg/lib/processor.js:369
    var progress = ll.split(/frame=([0-9\s]+)fps=([0-9\s]+)q=([0-9.\s]+)(L?)s
                      ^
TypeError: Cannot call method 'split' of undefined
    at FfmpegCommand.module.exports._getProgressFromStdErr (/home/ec2-user/EncoderInstance/node_modules/fluent-ffmpeg/lib/processor.js:369:23)
    at Socket.module.exports.saveToFile (/home/ec2-user/EncoderInstance/node_modules/fluent-ffmpeg/lib/processor.js:102:16)
    at Socket.EventEmitter.emit (events.js:88:17)
    at Pipe.onread (net.js:390:31)

The failure happens around 1/3 of the time - running the same code again (usually) works. This change adds a check for the 'll' variable before calling 'split' which has fixed the problem on my end.

The failure happens with the following code if it helps:

new ffmpeg({
        source  : ...
      , timeout : 60 \* 60 \* 24
    })
    .withVideoCodec('libx264')
    .withAudioCodec('libvo_aacenc')
    .withAudioChannels(2)
    .addOptions([
      .. 
    .toFormat('mp4')
    .onProgress(function(progress) {
      ..
    })
    .saveToFile(...

Thanks!
