### PR TITLE
Kill ffmpeg process when outputs stream closes

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -198,7 +198,7 @@ exports = module.exports = function Processor(command) {
 
       stream.on("close", function()
       {
-        logger.debug("Output stream closed, killing ffmpgeg process");
+        options.logger.debug("Output stream closed, killing ffmpgeg process");
         ffmpegProc.kill();
       });
     });


### PR DESCRIPTION
Notice if you use the express-stream sample & you kill the stream part way (say, close the browser tab mid video) the ffmpeg process keeps running until its done, or the timeout is hit.

This change proactively kills the ffmpeg proc when the output stream fires "close".
