### PR TITLE
Update lib/processor.js

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -226,6 +226,10 @@ exports = module.exports = function Processor(command) {
       result = result.replace('%b', self.options.inputfile.substr(0,self.options.inputfile.lastIndexOf('.')));
       return result;
     }
+    
+	function _is_array(input) {
+		return typeof(input) == 'object' && (input instanceof Array);
+	};
 
     function _screenShotInternal(callback) {
 
@@ -239,7 +243,7 @@ exports = module.exports = function Processor(command) {
         }
 
         // check if all timemarks are inside duration
-        if (timemarks !== null) {
+        if (_is_array(timemarks)) {
           for (var i = 0; i < timemarks.length; i++) {
             /* convert percentage to seconds */
             if( timemarks[i].indexOf('%') > 0 ) {
@@ -274,7 +278,7 @@ exports = module.exports = function Processor(command) {
           },
           function(taskcallback) {
             var offset;
-            if (timemarks !== null) {
+            if (_is_array(timemarks)) {
               // get timemark for current iteration
               offset = timemarks[(j - 1)];
             } else {
@@ -337,7 +341,7 @@ exports = module.exports = function Processor(command) {
     }
 
     filename = config.filename || 'tn_%ss';
-    if(!/%0*i/.test(filename) && timemarks.length > 1 ) {
+    if(!/%0*i/.test(filename) && _is_array(timemarks) && timemarks.length > 1 ) {
       // if there are multiple timemarks but no %i in filename add one
       // so we won't overwrite the same thumbnail with each timemark
       filename += '_%i';


### PR DESCRIPTION
I fixed the following problems about creating the screenshots without timemarks:

for (var i = 0; i < timemarks.length; i++) {
                             ^
TypeError: Cannot read property 'length' of undefined
