### PR TITLE
Fix onCodecData for newer ffmpeg

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -396,15 +396,29 @@ exports = module.exports = function Processor(command) {
   };
 
   this._checkStdErrForCodec = function(stderrString) {
-    var audio = /Audio\: ([^,]+)/.exec(stderrString);
-    var video = /Video\: ([^,]+)/.exec(stderrString);
-    var codecObject = { audio: '', video: '' };
+    var format= /Input #[0-9]+, ([^ ]+),/.exec(stderrString);
+    var dur   = /Duration\: ([^,]+)/.exec(stderrString);
+    var audio = /Audio\: (.*)/.exec(stderrString);
+    var video = /Video\: (.*)/.exec(stderrString);
+    var codecObject = { format: '', audio: '', video: '', duration: '' };
+
+    if (format && format.length > 1) {
+      codecObject.format = format[1];
+    }
+
+    if (dur && dur.length > 1) {
+      codecObject.duration = dur[1];
+    }
 
     if (audio && audio.length > 1) {
-      codecObject.audio = audio[1];
+      audio = audio[1].split(', ');
+      codecObject.audio = audio[0];
+      codecObject.audio_details = audio;
     }
     if (video && video.length > 1) {
-      codecObject.video = video[1];
+      video = video[1].split(', ');
+      codecObject.video = video[0];
+      codecObject.video_details = video;
     }
 
     var codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderrString);


### PR DESCRIPTION
The ffmpeg shipped with debian (unstable)
ffmpeg version 0.8.4-6:0.8.4-1, Copyright (c) 2000-2012 the Libav developers
ii  ffmpeg             6:0.8.4-1      amd64          Multimedia player, server, encoder and tr

changes slightly the output from '[q]' to 'ctrl-c',
this breaks the emission of the onCodecData signal.

this simple patch extends the regex to match for both cases.

Signed-off-by: Niv Sardi xaiki@evilgiggle.com
