### PR TITLE
Added a fix for metadata with .FLAC files

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -53,11 +53,11 @@ exports = module.exports = function Metadata(inputfile) {
         , video_bitrate = /bitrate: ([0-9]+) kb\/s/.exec(stderr) || none
         , fps           = /([0-9\.]+) (fps|tb\(r\))/.exec(stderr) || none
         , container     = /Input #0, ([a-zA-Z0-9]+),/.exec(stderr) || none
-        , title         = /(INAM|title)\s+:\s(.+)/.exec(stderr) || none
-        , artist        = /artist\s+:\s(.+)/.exec(stderr) || none
-        , album         = /album\s+:\s(.+)/.exec(stderr) || none
-        , track         = /track\s+:\s(.+)/.exec(stderr) || none
-        , date          = /date\s+:\s(.+)/.exec(stderr) || none
+        , title         = /(INAM|title)\s+:\s(.+)/i.exec(stderr) || none
+        , artist        = /artist\s+:\s(.+)/i.exec(stderr) || none
+        , album         = /album\s+:\s(.+)/i.exec(stderr) || none
+        , track         = /track\s+:\s(.+)/i.exec(stderr) || none
+        , date          = /date\s+:\s(.+)/i.exec(stderr) || none
         , video_stream  = /Stream #([0-9\.]+)([a-z0-9\(\)\[\]]*)[:] Video/.exec(stderr) || none
         , video_codec   = /Video: ([\w]+)/.exec(stderr) || none
         , duration      = /Duration: (([0-9]+):([0-9]{2}):([0-9]{2}).([0-9]+))/.exec(stderr) || none


### PR DESCRIPTION
Added ignore case to the metadata regex for title, artist, album, track and date as these are capitalised in .FLAC files.
