### PR TITLE
Added major_brand info in metadata

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -70,6 +70,7 @@ exports = module.exports = function Metadata(inputfile) {
         , is_synched    = (/start: 0.000000/.exec(stderr) !== null)
         , rotate        = /rotate[\s]+:[\s]([\d]{2,3})/.exec(stderr) || none
         , getVersion    = /ffmpeg version (?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)/i.exec(stderr)
+        , major_brand   = /major_brand\s+:\s([^\s]+)/.exec(stderr) || none
         , ffmpegVersion = 0;
 
       if (getVersion) {
@@ -94,6 +95,7 @@ exports = module.exports = function Metadata(inputfile) {
         , durationraw: duration[1] || ''
         , durationsec: duration[1] ? self.ffmpegTimemarkToSeconds(duration[1]) : 0
         , synched: is_synched
+        , major_brand: major_brand[1]
         , video: {
           container: container[1] || ''
           , bitrate: (video_bitrate.length > 1) ? parseInt(video_bitrate[1], 10) : 0


### PR DESCRIPTION
I added this info so mp4 files can be validated.
mp4 files can be "isom" or "mp42". isom is an old version of mp42

ffmpeg outputs this info as:

Metadata:
    major_brand     : isom

This regexp works OK. But It may be necessary to omit spaces between "major_brand"  and ": isom" in some cases to make it work also when it is like:

  Metadata:
    major_brand: isom

I am not very good with regexp so, my best shot was this.
