### PR TITLE
Remove -sameq option.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -529,9 +529,6 @@ exports = module.exports = function Processor(command) {
           args.push('-minrate', this.options.video.bitrate + 'k');
           args.push('-bufsize', '3M');
         }
-      } else {
-        // use same quality for output as used in input
-        args.push('-sameq');
       }
       if (this.options.video.codec) {
         args.push('-vcodec', this.options.video.codec);


### PR DESCRIPTION
According to [ffmpeg.org](http://ffmpeg.org/trac/ffmpeg/wiki/Option%20'-sameq'%20does%20NOT%20mean%20'same%20quality'), the -sameq option does **not** mean "same quality", so I don't think fluent-ffmpeg should default to -sameq if a video bitrate isnt' given.
