### PR TITLE
change in progress output

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -374,7 +374,7 @@ exports = module.exports = function Processor(command) {
     var ll = lastLine[lastLine.length - 2];
     var progress;
     if (ll) {
-      progress = ll.split(/frame=([0-9\s]+)fps=([0-9\s]+)q=([0-9\.\s]+)(L?)size=([0-9\s]+)kB time=(([0-9]{2}):([0-9]{2}):([0-9]{2}).([0-9]{2})) bitrate=([0-9\.\s]+)kbits/ig);    
+      progress = ll.split(/frame=([0-9\s]+)fps=([0-9\.\s]+)q=([0-9\.\s]+)(L?)size=([0-9\s]+)kB time=(([0-9]{2}):([0-9]{2}):([0-9]{2}).([0-9]{2})) bitrate=([0-9\.\s]+)kbits/ig);    
     }
     if (progress && progress.length > 10) {
       // build progress report object


### PR DESCRIPTION
The Libav team's ffmpeg has a fractional part in the fps, which fails the current regex
