### PR TITLE
destroy non-fs streams correctly

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -287,6 +287,10 @@ exports = module.exports = function Processor(command) {
           if (!options.inputstream) {
             return callback(code, stderr);
           }
+          if (!options.inputstream.fd) {
+            options.inputstream.destroy();
+            return callback(code, stderr);
+          }
           fs.close(options.inputstream.fd, function() {
             callback(code, stderr);
           });


### PR DESCRIPTION
not every input streams comes with a fd.
