### PR TITLE
Update processor.js - allow HTTP streams to be written out to.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -284,7 +284,7 @@ exports = module.exports = function Processor(command) {
         }
 
         var cb_ = function() {
-          if (!options.inputstream) {
+          if (!options.inputstream || !options.inputstream.fd) {
             return callback(code, stderr);
           }
           fs.close(options.inputstream.fd, function() {


### PR DESCRIPTION
in order to process an output stream to an HTTP response, 
the stream does not have the fd property and should not be closed with fs.close - adding the extra check here allows one to write a streaming server that applies filters from one http server to the next
