### PR TITLE
fix .withAudioQuality argument handling

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -665,7 +665,7 @@ exports = module.exports = function Processor(command) {
       if (this.options.audio.frequency) {
         args.push('-ar', this.options.audio.frequency);
       }
-      if (this.options.audio.quality) {
+      if (this.options.audio.quality || this.options.audio.quality === 0) {
         args.push('-aq', this.options.audio.quality);
       }
     }


### PR DESCRIPTION
the value of -aq could be 0, but it's not working when you set .withAudioQuality(0) in original code
