### PR TITLE
Thumbnails: pass additional options to ffmpeg invocation

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -456,19 +456,28 @@ exports = module.exports = function Processor(command) {
             var input = self.escapedPath(self.options.inputfile, true);
 
             // build screenshot command
+            var args = [
+              '-ss', Math.floor(offset * 100) / 100,
+              '-i', input,
+              '-vcodec', 'mjpeg',
+              '-vframes', '1',
+              '-an',
+              '-f', 'rawvideo',
+              '-s', self.options.video.size,
+            ];
+            if (self.options.additional) {
+              if (self.options.additional.length > 0) {
+                self.options.additional.forEach(function(el) {
+                  args.push(el);
+                });
+              }
+            }
+            args.push('-y', target);
+
             var command = [
               self.ffmpegPath,
-              [
-                '-ss', Math.floor(offset * 100) / 100,
-                '-i', input,
-                '-vcodec', 'mjpeg',
-                '-vframes', '1',
-                '-an',
-                '-f', 'rawvideo',
-                '-s', self.options.video.size,
-                '-y', target
-                ].join(' ')
-            ];
+              args.join(" ")
+            ]
 
             j++;
 


### PR DESCRIPTION
.addOption and .addOptions had no effect on thumbnail generation. Example use
case is adding vfilters to the output with addOption("-vf", "hflip").
