### PR TITLE
Fix Travis erroring due to Medibuntu shutdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 before_script:
+  - sudo apt-get update
   - sudo apt-get install -y ffmpeg libavcodec-extra-53
 language: node_js
 node_js:


### PR DESCRIPTION
Although this doesn't actually fix the tests, it does get them running on Travis so future pull-requests & development can be assessed.
