### PR TITLE
Fix writeToStream writing to stream after closing it

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -334,6 +334,38 @@ exports = module.exports = function Processor(command) {
         stream.write(chunk);
       });
 
+      var fdClosed = false;
+      var exitCode;
+
+      ffmpegProc.stdout.on('end', function() {
+        if (stream.fd) {
+          return fs.close(stream.fd, function() {
+            fdClosed = true;
+            if (typeof exitCode !== 'undefined') {
+              // Process has already exited
+              cb_(exitCode);
+            }
+          });
+        }
+
+        if (stream.end) {
+          stream.end();
+        }
+      });
+
+      var cb_ = function(code) {
+        if (!options.inputstream || !options.inputstream.fd) {
+          return callback(code, stderr);
+        }
+        if (!options.inputstream.fd) {
+          options.inputstream.destroy();
+          return callback(code, stderr);
+        }
+        fs.close(options.inputstream.fd, function() {
+          callback(code, stderr);
+        });
+      };
+
       ffmpegProc.on('exit', function(code, signal) {
         if (processTimer) {
           clearTimeout(processTimer);
@@ -343,28 +375,15 @@ exports = module.exports = function Processor(command) {
           return callback(code, stderr);
         }
 
-        var cb_ = function() {
-          if (!options.inputstream || !options.inputstream.fd) {
-            return callback(code, stderr);
-          }
-          if (!options.inputstream.fd) {
-            options.inputstream.destroy();
-            return callback(code, stderr);
-          }
-          fs.close(options.inputstream.fd, function() {
-            callback(code, stderr);
-          });
-        };
-
         if (stream.fd) {
-          return fs.close(stream.fd, cb_);
-        }
-        if (stream.end) {
-          stream.end();
+          exitCode = code;
+          if (fdClosed) {
+            // Fd already closed
+            cb_(code);
+          }
         } else {
-          callback(code, "stream will not be closed");
+          cb_(code)
         }
-        cb_();
       });
 
       stream.on("close", function()


### PR DESCRIPTION
writeToStream closes the output stream when the ffmpeg process terminates, but 'data' events on the process stdout stream can still happen after that.

This patch fixes this problem by closing the stream on the stdout 'end' event.
