### PR TITLE
FPS Metadata regex fix for FFMpeg 1.2.1

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -58,7 +58,7 @@ exports = module.exports = function Metadata(command) {
         , aspect        = /DAR ([0-9\:]+)/.exec(stderr) || none
         , pixel        = /[SP]AR ([0-9\:]+)/.exec(stderr) || none
         , video_bitrate = /bitrate: ([0-9]+) kb\/s/.exec(stderr) || none
-        , fps           = /([0-9\.]+) (fps|tb\(r\))/.exec(stderr) || none
+        , fps           = /(INAM|fps)\s+:\s(.+)/i.exec(stderr) || none
         , container     = /Input #0, ([a-zA-Z0-9]+),/.exec(stderr) || none
         , title         = /(INAM|title)\s+:\s(.+)/i.exec(stderr) || none
         , artist        = /artist\s+:\s(.+)/i.exec(stderr) || none
@@ -113,7 +113,7 @@ exports = module.exports = function Metadata(command) {
           }
           , resolutionSquare: {}
           , rotate: rotate.length > 1 ? parseInt(rotate[1], 10) : 0
-          , fps: fps.length > 1 ? parseFloat(fps[1]) : 0.0
+          , fps: fps.length > 1 ? parseFloat(fps[2]) : 0.0
           , stream: video_stream.length > 1 ? parseFloat(video_stream[1]) : 0.0
         }
         , audio: {


### PR DESCRIPTION
These changes worked for me, I am not great at regex but copying the same line being used for 'title' and using it for 'fps' I was able to get the proper values I needed and did not see any regression upon testing.

Fixes #169 
