### PR TITLE
Fix crash in node and properly pipe streams.

### DIFF
--- a/examples/express-stream.js
+++ b/examples/express-stream.js
@@ -17,7 +17,7 @@ app.get('/video/:filename', function(req, res) {
     // use the 'flashvideo' preset (located in /lib/presets/flashvideo.js)
     .usingPreset('flashvideo')
     // save to stream
-    .writeToStream(res, function(retcode, error){
+    .writeToStream(res, {end:true}, function(retcode, error){
       console.log('file has been converted succesfully');
     });
 });

--- a/examples/stream.js
+++ b/examples/stream.js
@@ -9,6 +9,6 @@ var proc = new ffmpeg({ source: '/path/to/your_movie.avi', nolog: true })
   // use the 'flashvideo' preset (located in /lib/presets/flashvideo.js)
   .usingPreset('flashvideo')
   // save to stream
-  .writeToStream(stream, function(retcode, error){
+  .writeToStream(stream, {end:true}, function(retcode, error){ //end = true, close output stream after writing
     console.log('file has been converted succesfully');
   });

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -268,7 +268,12 @@ exports = module.exports = function Processor(command) {
 
   }
 
-  command.prototype.writeToStream = function(stream, callback) {
+  command.prototype.writeToStream = function(stream, pipeOptions, callback) {
+
+    if(typeof pipeOptions == 'function'){
+        callback = pipeOptions;
+        pipeOptions = {};
+    }
 
     callback = callback || function(){};
 
@@ -330,40 +335,11 @@ exports = module.exports = function Processor(command) {
         }
       });
 
-      ffmpegProc.stdout.on('data', function(chunk) {
-        stream.write(chunk);
-      });
+      ffmpegProc.stdout.pipe(stream, pipeOptions);
 
-      var fdClosed = false;
       var exitCode;
-
-      ffmpegProc.stdout.on('end', function() {
-        if (stream.fd) {
-          return fs.close(stream.fd, function() {
-            fdClosed = true;
-            if (typeof exitCode !== 'undefined') {
-              // Process has already exited
-              cb_(exitCode);
-            }
-          });
-        }
-
-        if (stream.end) {
-          stream.end();
-        }
-      });
-
       var cb_ = function(code) {
-        if (!options.inputstream || !options.inputstream.fd) {
-          return callback(code, stderr);
-        }
-        if (!options.inputstream.fd) {
-          options.inputstream.destroy();
-          return callback(code, stderr);
-        }
-        fs.close(options.inputstream.fd, function() {
-          callback(code, stderr);
-        });
+        callback(code, stderr);
       };
 
       ffmpegProc.on('exit', function(code, signal) {
@@ -375,15 +351,7 @@ exports = module.exports = function Processor(command) {
           return callback(code, stderr);
         }
 
-        if (stream.fd) {
-          exitCode = code;
-          if (fdClosed) {
-            // Fd already closed
-            cb_(code);
-          }
-        } else {
-          cb_(code)
-        }
+        cb_(code)
       });
 
       stream.on("close", function()

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -253,7 +253,7 @@ describe('Processor', function() {
       var outstream = fs.createWriteStream(testFile);
       new Ffmpeg({ source: this.testfile, nolog: true })
         .usingPreset('flashvideo')
-        .writeToStream(outstream, function(code, stderr) {
+        .writeToStream(outstream, {end:true}, function(code, stderr) {
           fs.exists(testFile, function(exist) {
             exist.should.true;
             // check filesize to make sure conversion actually worked


### PR DESCRIPTION
This also fixes (eh, works around) this issue: https://github.com/joyent/node/issues/7063

writeToStream gained a new argument, 'pipeOptions'. Which are passed to stdout.pipe(stream, pipeOptions). By setting these to {end:true}, it allows fluent-ffpmpeg to close the stream after it's done writing.
