### PR TITLE
Fix timemark to seconds when no hours/minutes are present

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -47,16 +47,21 @@ exports = module.exports = function Extensions(command) {
     var parts = timemark.split(':');
     var secs = 0;
 
-    // add hours
-    secs += parseInt(parts[0], 10) * 3600;
-    // add minutes
-    secs += parseInt(parts[1], 10) * 60;
-
     // split sec/msec part
-    var secParts = parts[2].split('.');
+    var secParts = parts.pop().split('.');
 
     // add seconds
     secs += parseInt(secParts[0], 10);
+
+    if (parts.length) {
+      // add minutes
+      secs += parseInt(parts.pop(), 10) * 60;
+    }
+
+    if (parts.length) {
+      // add hours
+      secs += parseInt(parts.pop(), 10) * 3600;
+    }
 
     return secs;
   };


### PR DESCRIPTION
This pull request fixes an error that happens when ffmpeg reports a timemark without hours or minutes (eg. "12.345" instead of "00:00:12.345"). This case happened to me once when encoding a file.

It is also able to handle timemarks with minutes but not hours (ie. "00:12.345") even if I have never seen this case.
