### PR TITLE
Escape more than the first space on the input file paths

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -721,14 +721,14 @@ exports = module.exports = function Processor(command) {
         args.push('-r', this.options.video.fpsInput);
       }
       if (/^[a-z]+:\/\//.test(this.options.inputfile)) {
-        args.push('-i', this.options.inputfile.replace(' ', '%20'));
+        args.push('-i', this.options.inputfile.replace(/ /g, '%20'));
       } else if (/%\d*d/.test(this.options.inputfile)) { // multi-file format - http://ffmpeg.org/ffmpeg.html#image2-1
-        args.push('-i', this.options.inputfile.replace(' ', '\ '));
+        args.push('-i', this.options.inputfile.replace(/ /g, '\ '));
       } else {
         var fstats = fs.statSync(this.options.inputfile);
         if (fstats.isFile()) {
           // fix for spawn call with path containing spaces and quotes
-          args.push('-i', this.options.inputfile.replace(/ /g, "\ ")
+          args.push('-i', this.options.inputfile.replace(/ /g, '\ ')
             .replace(/'/g, "\'")
             .replace(/"/g, "\""));
         } else {
@@ -744,7 +744,7 @@ exports = module.exports = function Processor(command) {
     	//Check if input URI
     	if(/^[a-z]+:\/\//.test(this.options.inputfile)) {
     		// add input with live flag
-    		args.push('-i', this.options.inputfile.replace(' ', '%20')+' live=1');
+    		args.push('-i', this.options.inputfile.replace(/ /g, '%20')+' live=1');
     	}else {
     		this.options.logger.error('live input URI is not valid');
     		throw new Error('live input URI is not valid');


### PR DESCRIPTION
Previously only the first space of the input file paths were matched causing potential failures.
