### PR TITLE
Remove default timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ var command = new FFmpeg({
         // Custom presets folder
         preset: './presets',
 
-        // Processing timeout in seconds, defaults to 30.
+        // Processing timeout in seconds, defaults to no timeout
         // You can disable the timeout by passing 0.
         timeout: 30,
 

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -15,7 +15,7 @@ function FfmpegCommand(args) {
   EventEmitter.call(this);
 
   var source = args.source,
-      timeout = (typeof args === 'object' && 'timeout' in args) ? args.timeout : 30,
+      timeout = (typeof args === 'object' && 'timeout' in args) ? args.timeout : 0,
       priority = args.priority || 0,
       logger = args.logger || null,
       nologging = args.nolog || false,


### PR DESCRIPTION
I think having a timeout by default is misleading, especially for new users who haven't read the documentation thoroughly...
