### PR TITLE
Enable using flvmeta instead of flvtool2

### DIFF
--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -221,5 +221,50 @@ exports = module.exports = function capabilities(FfmpegCommand) {
       callback(hasFlvtool2 === 'yes');
     }
   };
+
+  FfmpegCommand.prototype.hasFlvmeta = function(callback) {
+    var hasFlvmeta = Registry.instance.get('hasFlvmeta');
+    if (!hasFlvmeta) {
+      exec('which flvmeta', function(err, stdout) {
+        if (stdout !== '') {
+          hasFlvmeta = 'yes';
+        } else {
+          hasFlvmeta = 'no';
+        }
+
+        Registry.instance.set('hasFlvmeta', hasFlvmeta);
+        callback(hasFlvmeta === 'yes');
+      });
+    } else {
+      callback(hasFlvmeta === 'yes');
+    }
+  };
+
+  FfmpegCommand.prototype.hasFlvInjector = function(callback) {
+    var hasFlvInjector = Registry.instance.get('hasFlvInjector');
+    if (!hasFlvInjector) {
+      var self = this;
+      this.hasFlvmeta(function(hasFlvmeta) {
+        if (hasFlvmeta) {
+          hasFlvInjector = 'flvmeta';
+          Registry.instance.set('hasFlvInjector', hasFlvInjector);
+          callback('flvmeta');
+        } else {
+          self.hasFlvtool2(function(hasFlvtool2) {
+            if (hasFlvtool2) {
+              hasFlvInjector = 'flvtool2';
+            } else {
+              hasFlvInjector = 'none';
+            }
+
+            Registry.instance.set('hasFlvInjector', hasFlvInjector);
+            callback(hasFlvInjector === 'none' ? false : hasFlvInjector);
+          });
+        }
+      });
+    } else {
+      callback(hasFlvInjector === 'none' ? false : hasFlvInjector);
+    }
+  };
 };
-	
+

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -24,6 +24,7 @@ exports = module.exports = function processor(FfmpegCommand) {
 
     var self = this;
     var options = this.options;
+    var flvInjector = false;
 
     // Check for flvtool2 presence if needed
     if (options._updateFlvMetadata) {
@@ -34,11 +35,12 @@ exports = module.exports = function processor(FfmpegCommand) {
         return doProcess();
       }
 
-      self.hasFlvtool2(function(hasFlvtool2) {
-        if (hasFlvtool2) {
+      self.hasFlvInjector(function(_flvInjector) {
+        if (_flvInjector) {
+          flvInjector = _flvInjector;
           doProcess();
         } else {
-          self.emit('error', new Error('Cannot find flvtool2'));
+          self.emit('error', new Error('Cannot find flvtool2 or flvmeta'));
         }
       });
     } else {
@@ -87,7 +89,7 @@ exports = module.exports = function processor(FfmpegCommand) {
             emitEnd(err, stdout, stderr);
           } else {
             if (options._updateFlvMetadata) {
-              spawn('flvtool2', ['-U', options.outputfile])
+              spawn(flvInjector, ['-U', options.outputfile])
                 .on('error', function(err) {
                   emitEnd(new Error('Error running flvtool2: ' + err.message));
                 })
@@ -126,7 +128,7 @@ exports = module.exports = function processor(FfmpegCommand) {
           processTimer = setTimeout(function() {
             var msg = 'process ran into a timeout (' + self.options.timeout + 's)';
             options.logger.warn(msg);
-            
+
             emitEnd(new Error(msg), stdout, stderr);
             self.ffmpegProc.kill();
           }, options.timeout * 1000);
@@ -645,7 +647,7 @@ exports = module.exports = function processor(FfmpegCommand) {
     var stderrClosed = false;
 
     var process = spawn(command, args, options);
-    
+
     if (process.stderr) {
       process.stderr.setEncoding('utf8');
     }


### PR DESCRIPTION
Ubuntu 14.04 doesn't have flvtool2 anylonger; flvmeta provides the same features (with the same command line) and seems to be a lot faster...

This pull request enables using either flvmeta or flvtool2, whichever is available on the system.
