### PR TITLE
Fix for video resolution detection RegEx

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -142,7 +142,7 @@ exports = module.exports = function Metadata(FfmpegCommand) {
           , video_stream  = /Stream #([0-9\.]+)([a-z0-9\(\)\[\]]*)[:] Video/.exec(stderr) || none
           , video_codec   = /Video: ([\w]+)/.exec(stderr) || none
           , duration      = /Duration: (([0-9]+):([0-9]{2}):([0-9]{2}).([0-9]+))/.exec(stderr) || none
-          , resolution    = /(([0-9]{2,5})x([0-9]{2,5}))/.exec(stderr) || none
+          , resolution    = /Video: .+ (([0-9]{2,5})x([0-9]{2,5}))/.exec(stderr) || none
           , audio_bitrate = /Audio:(.)*, ([0-9]+) kb\/s/.exec(stderr) || none
           , sample_rate   = /([0-9]+) Hz/i.exec(stderr) || none
           , audio_codec   = /Audio: ([\w]+)/.exec(stderr) || none


### PR DESCRIPTION
For me it fails when filename contains a typo like video2920x1080.mp4, while video is actually 1920x1080.
