### PR TITLE
Expose ffmpeg and ffprobe path set functions

### DIFF
--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -19,20 +19,20 @@ function copy(src, dest) {
 }
 
 exports = module.exports = function capabilities(FfmpegCommand) {
-  FfmpegCommand.prototype.ffmpegPath = process.env.FFMPEG_PATH || 'ffmpeg';
-  FfmpegCommand.prototype.ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
+  FfmpegCommand.ffmpegPath = process.env.FFMPEG_PATH || 'ffmpeg';
+  FfmpegCommand.ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
 
-  FfmpegCommand.prototype.setFfmpegPath = function(path) {
-    this.ffmpegPath = path;
+  FfmpegCommand.setFfmpegPath = function(path) {
+    FfmpegCommand.ffmpegPath = path;
   };
 
-  FfmpegCommand.prototype.setFfprobePath = function(path) {
-    this.ffprobePath = path;
+  FfmpegCommand.setFfprobePath = function(path) {
+    FfmpegCommand.ffprobePath = path;
   };
 
-  FfmpegCommand.prototype.determineFfmpegPath = function() {
-    if (this.ffmpegPath) {
-      return this.ffmpegPath;
+  FfmpegCommand.determineFfmpegPath = function() {
+    if (FfmpegCommand.ffmpegPath) {
+      return FfmpegCommand.ffmpegPath;
     }
     return 'ffmpeg';
   };

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -61,7 +61,7 @@ exports = module.exports = function Metadata(FfmpegCommand) {
     var stdout = '';
     var stdoutClosed = false;
 
-    var ffprobe = spawn(FfmpegCommand.prototype.ffprobePath, [
+    var ffprobe = spawn(FfmpegCommand.ffprobePath, [
         '-show_streams',
         '-show_format',
         filename

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -683,7 +683,7 @@ exports = module.exports = function processor(FfmpegCommand) {
   };
 
   FfmpegCommand.prototype._spawnFfmpeg = function(args, options, callback) {
-    var command = this.ffmpegPath;
+    var command = FfmpegCommand.ffmpegPath;
     var self = this;
 
     if (typeof options === 'function') {


### PR DESCRIPTION
The paths for `ffmpeg` and `ffprobe` binaries are constants and shouldn't be in the `FfmpegCommand` prototype to be set / changed on a per instance basis.

Thus the two string properties `ffmpegPath` and `ffprobePath` are now static. Likely i have properly exposed the `setFfmpegPath()` and `setFfprobePath()` methods as static so they can be utilized on a system-wide approach vs per-instance, which for the case of ffprobe it was just impossible to use the `setFfprobePath()` method as the ffprobe module reached for the `FfmpegCommand.prototype.ffprobePath` to get the path value.

This now enables to set the path programmatically by:

``` js
var Ffmpeg = require('fluent-ffmpeg');

Ffmpeg.setFfmpegPath('/whatever/ffmpeg');
Ffmpeg.setFfprobePath('/whatever/ffrobe');
```

Which in combination with the [ffmpeg-binary-linux-64bit](https://github.com/thanpolas/ffmpeg-binary-linux-64bit) package that contains static linux binaries will solve the issue of pushing codebases to PaaS or environments that we cannot control system-wide library installs:

``` js
var Ffmpeg = require('fluent-ffmpeg');
var ffmpegBin = require('ffmpeg-binary-linux-64bit');

Ffmpeg.setFfmpegPath(ffmpegBin());
Ffmpeg.setFfprobePath(ffmpegBin.ffprobe());
```
