### PR TITLE
Added support for using v4l2 as input format

### DIFF
--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -531,6 +531,9 @@ module.exports = function(proto) {
         }
       });
 
+      // Fix to allow v4l2 input
+      data['v4l2']['canDemux'] = true;
+
       callback(null, cache.formats = data);
     });
   };


### PR DESCRIPTION
FFmpeg outputs two v4l2 formats

```
"v4l2":{"description":"Video4Linux2 output device","canDemux":false,"canMux":true},
"video4linux2,v4l2":{"description":"Video4Linux2 device grab","canDemux":true,"canMux":false}
```

and this results in fluent-ffmpeg only accepting `-f video4linux2,v4l2` as the v4l2 input format. I've set the first output's canDemux to true in order to recognize `-f v4l2` as a valid input format. 
You could also change the regex to recognize formats with commas in them but this is a quick fix. 
