### PR TITLE
Simplify ffprobe output parsing using -print_output json

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -4,56 +4,6 @@
 var spawn = require('child_process').spawn;
 
 
-function legacyTag(key) { return key.match(/^TAG:/); }
-function legacyDisposition(key) { return key.match(/^DISPOSITION:/); }
-
-function parseFfprobeOutput(out) {
-  var lines = out.split(/\r\n|\r|\n/);
-  var data = {
-    streams: []
-  };
-
-  function parseBlock() {
-    var data = {};
-
-    var line = lines.shift();
-    while (line) {
-      if (line.match(/^\[\//)) {
-        return data;
-      }
-
-      var kv = line.match(/^([^=]+)=(.*)$/);
-      if (kv) {
-        if (kv[2].match(/^[0-9]+(.[0-9]+)?$/)) {
-          data[kv[1]] = Number(kv[2]);
-        } else {
-          data[kv[1]] = kv[2];
-        }
-      }
-
-      line = lines.shift();
-    }
-
-    return data;
-  }
-
-  var line = lines.shift();
-  while (line) {
-    if (line === '[STREAM]') {
-      var stream = parseBlock();
-      data.streams.push(stream);
-    } else if (line === '[FORMAT]') {
-      data.format = parseBlock();
-    }
-
-    line = lines.shift();
-  }
-
-  return data;
-}
-
-
-
 module.exports = function(proto) {
   /**
    * A callback passed to the {@link FfmpegCommand#ffprobe} method.
@@ -119,6 +69,7 @@ module.exports = function(proto) {
       var ffprobe = spawn(path, [
         '-show_streams',
         '-show_format',
+        '-print_format', 'json',
         input.source
       ]);
 
@@ -143,33 +94,7 @@ module.exports = function(proto) {
           }
 
           // Process output
-          var data = parseFfprobeOutput(stdout);
-
-          // Handle legacy output with "TAG:x" and "DISPOSITION:x" keys
-          [data.format].concat(data.streams).forEach(function(target) {
-            var legacyTagKeys = Object.keys(target).filter(legacyTag);
-
-            if (legacyTagKeys.length) {
-              target.tags = target.tags || {};
-
-              legacyTagKeys.forEach(function(tagKey) {
-                target.tags[tagKey.substr(4)] = target[tagKey];
-                delete target[tagKey];
-              });
-            }
-
-            var legacyDispositionKeys = Object.keys(target).filter(legacyDisposition);
-
-            if (legacyDispositionKeys.length) {
-              target.disposition = target.disposition || {};
-
-              legacyDispositionKeys.forEach(function(dispositionKey) {
-                target.disposition[dispositionKey.substr(12)] = target[dispositionKey];
-                delete target[dispositionKey];
-              });
-            }
-          });
-
+          var data = JSON.parse(stdout);
           callback(null, data);
         }
       }


### PR DESCRIPTION
Produces better output than manual parsing.
As a side benefit, this method also supports avprobe output.
