### PR TITLE
Add basic support for parsing avprobe output

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -13,12 +13,21 @@ function parseFfprobeOutput(out) {
     streams: []
   };
 
+  var prober = 'ffprobe';
+  if (out.indexOf('# avprobe output') === 0) {
+    prober = 'avprobe';
+    lines.shift();
+  }
+
   function parseBlock() {
     var data = {};
 
     var line = lines.shift();
     while (line) {
-      if (line.match(/^\[\//)) {
+      if (
+        (prober === 'ffprobe' && line.match(/^\[\//)) ||
+        (prober === 'avprobe' && line.match(/^(\r\n|\r|\n)$/))
+      ) {
         return data;
       }
 
@@ -38,11 +47,17 @@ function parseFfprobeOutput(out) {
   }
 
   var line = lines.shift();
-  while (line) {
-    if (line === '[STREAM]') {
+  while (line || lines.length) {
+    if (
+      (prober === 'ffprobe' && line === '[STREAM]') ||
+      (prober === 'avprobe' && line.match(/^\[streams\.stream\.\d+\]$/))
+    ) {
       var stream = parseBlock();
       data.streams.push(stream);
-    } else if (line === '[FORMAT]') {
+    } else if (
+      (prober === 'ffprobe' && line === '[FORMAT]') ||
+      (prober === 'avprobe' && line === '[format]')
+    ) {
       data.format = parseBlock();
     }
 


### PR DESCRIPTION
Does not anything away from parsing ffprobe output, but adds some basic support for avprobe output.
Tags, for example, are not supported yet.
