### PR TITLE
Fix number regex

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -24,7 +24,7 @@ function parseFfprobeOutput(out) {
 
       var kv = line.match(/^([^=]+)=(.*)$/);
       if (kv) {
-        if (kv[2].match(/^[0-9]+(.[0-9]+)?$/)) {
+        if (kv[2].match(/^[0-9]+(\.[0-9]+)?$/)) {
           data[kv[1]] = Number(kv[2]);
         } else {
           data[kv[1]] = kv[2];


### PR DESCRIPTION
This fixes the 'NaN' output seen when parsing videos as mentioned here:

https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/304

Some numbers values would get incorrectly detected as numbers, like "434x2257".
I fixed the regex.
