### PR TITLE
Do not add _1 to file name when only one screenshot is produced

### DIFF
--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -215,7 +215,7 @@ module.exports = function recipes(proto) {
           pattern += '.png';
         }
 
-        if (config.timemarks.length > 0 && !pattern.match(/%(s|0*i)/)) {
+        if (config.timemarks.length > 1 && !pattern.match(/%(s|0*i)/)) {
           var ext = path.extname(pattern);
           pattern = path.join(path.dirname(pattern), path.basename(pattern, ext) + '_%i' + ext);
         }

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -528,6 +528,13 @@ describe('Processor', function() {
       { count: 3, filename: 'shot_%r.png', size: '150x?' },
       ['shot_150x112_1.png', 'shot_150x112_2.png', 'shot_150x112_3.png']
     );
+
+    testScreenshots(
+      'a single screenshot should not have a _1 file name suffix',
+      'no_suffix',
+      { timemarks: [ 0.5 ] },
+      ['tn.png']
+    );
   });
 
   describe('saveToFile', function() {


### PR DESCRIPTION
This is about taking a single screenshot from a video.

The documentation suggests that a _1 is only appended to the file name, if multiple screenshots are generated:

> If multiple timemarks are passed and no variable format token ('%s' or '%i') is specified in the filename pattern, _%i will be added automatically.

Also, this comment from the code seems to convey the intention that a numbered suffix should only be used for multiple screenshots (from lib/recipes.js):

> // Add '_%i' to pattern when requesting multiple screenshots and no variable token is present

But with this code a suffix was appended although there is only one timestamp:

```
.screenshot({                                                                  
  timestamps: ['50%'],                                                         
  folder: path.dirname(output),                                                
  filename: path.basename(output),                                             
  size: '320x?',                                                               
});
```

This PR fixes this by changing a check in fixPatterns in `lib/recipes.js` and adds a test.

Note: I had 5 failing tests before and after the change, so I'm not 100% I didn't break anything else. Not sure why. Also, it seems the tests regarding the screenshots didn't get executed at all with `make test`, maybe because of other failing tests in processor.test.js, so I used something like `mocha ... --grep 'a single screenshot'` to verify that the new test fails without the change and passes after the change in lib/recipes.js.

Oh, one more thing: Awesome project. :clap:
