### PR TITLE
Fix incorrect parsing of format capabilities. #323

### DIFF
--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -524,11 +524,20 @@ module.exports = function(proto) {
         var match = line.match(formatRegexp);
         if (match) {
           match[3].split(',').forEach(function(format) {
-            data[format] = {
-              description: match[4],
-              canDemux: match[1] === 'D',
-              canMux: match[2] === 'E'
-            };
+            if (!(format in data)) {
+              data[format] = {
+                description: match[4],
+                canDemux: false,
+                canMux: false
+              };
+            }
+
+            if (match[1] === 'D') {
+              data[format].canDemux = true;
+            }
+            if (match[2] === 'E') {
+              data[format].canMux = true;
+            }
           });
         }
       });


### PR DESCRIPTION
This addresses parsing of `ffmpeg -formats` when a format appears on multiple lines.

I have not included a test because it appears the tests interact directly with ffmpeg instead of utilizing fixtures/mocks. Have you considered utilizing something like [sinon](http://sinonjs.org) so that tests don't need to touch ffmpeg/ffprobe/other?
