### PR TITLE
Update processor.js

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -628,7 +628,7 @@ module.exports = function(proto) {
    */
   proto.kill = function(signal) {
     if (!this.ffmpegProc) {
-      this.options.logger.warn('No running ffmpeg process, cannot send signal');
+      this.logger.warn('No running ffmpeg process, cannot send signal');
     } else {
       this.ffmpegProc.kill(signal || 'SIGKILL');
     }


### PR DESCRIPTION
Fixes old call to `this.options.logger` in processor.

Fixes crash:

```
/home/simon/public_html/node-clementine-server/node_modules/fluent-ffmpeg/lib/processor.js:631
      this.options.logger.warn('No running ffmpeg process, cannot send signal'
                          ^
TypeError: Cannot call method 'warn' of undefined
    at FfmpegCommand.proto.kill (/home/simon/public_html/node-clementine-server/node_modules/fluent-ffmpeg/lib/processor.js:631:27)
    at Player.stop (/home/simon/public_html/node-clementine-server/lib/player.js:91:18)
    at FfmpegCommand.<anonymous> (/home/simon/public_html/node-clementine-server/lib/player.js:38:8)
    at FfmpegCommand.emit (events.js:98:17)
    at emitEnd (/home/simon/public_html/node-clementine-server/node_modules/fluent-ffmpeg/lib/processor.js:415:16)
    at endCB (/home/simon/public_html/node-clementine-server/node_modules/fluent-ffmpeg/lib/processor.js:564:15)
    at handleExit (/home/simon/public_html/node-clementine-server/node_modules/fluent-ffmpeg/lib/processor.js:155:11)
    at ChildProcess.<anonymous> (/home/simon/public_html/node-clementine-server/node_modules/fluent-ffmpeg/lib/processor.js:169:11)
    at ChildProcess.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:810:12)
```
