### PR TITLE
allow passing additional output options for ffprobe

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -105,6 +105,8 @@ module.exports = function(proto) {
       return callback(new Error('Cannot run ffprobe on stream input'));
     }
 
+    var args = ['-show_streams', '-show_format'].concat(this._currentOutput.options.get(), input.source);
+
     // Find ffprobe
     this._getFfprobePath(function(err, path) {
       if (err) {
@@ -119,11 +121,7 @@ module.exports = function(proto) {
       var stderrClosed = false;
 
       // Spawn ffprobe
-      var ffprobe = spawn(path, [
-        '-show_streams',
-        '-show_format',
-        input.source
-      ]);
+      var ffprobe = spawn(path, args);
 
       ffprobe.on('error', function(err) {
         callback(err);
@@ -212,4 +210,3 @@ module.exports = function(proto) {
     });
   };
 };
-

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -78,16 +78,33 @@ module.exports = function(proto) {
    * @method FfmpegCommand#ffprobe
    * @category Metadata
    *
-   * @param {Number} [index] 0-based index of input to probe (defaults to last input)
+   * @param {?Number} [index] 0-based index of input to probe (defaults to last input)
+   * @param {?String[]} [options] array of output options to return
    * @param {FfmpegCommand~ffprobeCallback} callback callback function
    *
    */
-  proto.ffprobe = function(index, callback) {
-    var input;
+  proto.ffprobe = function() {
+    var input, index = null, options = [], callback;
 
-    if (typeof callback === 'undefined') {
-      callback = index;
+    // the last argument should be the callback
+    callback = arguments[arguments.length - 1];
 
+    // map the arguments to the correct variable names
+    switch (arguments.length) {
+      case 3:
+        index = arguments[0];
+        options = arguments[1];
+        break;
+      case 2:
+        if (typeof arguments[0] === 'number') {
+          index = arguments[0];
+        } else if (Array.isArray(arguments[0])) {
+          options = arguments[0];
+        }
+        break;
+    }
+
+    if (index === null) {
       if (!this._currentInput) {
         return callback(new Error('No input specified'));
       }
@@ -105,8 +122,6 @@ module.exports = function(proto) {
       return callback(new Error('Cannot run ffprobe on stream input'));
     }
 
-    var args = ['-show_streams', '-show_format'].concat(this._currentOutput.options.get(), input.source);
-
     // Find ffprobe
     this._getFfprobePath(function(err, path) {
       if (err) {
@@ -121,7 +136,7 @@ module.exports = function(proto) {
       var stderrClosed = false;
 
       // Spawn ffprobe
-      var ffprobe = spawn(path, args);
+      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, input.source));
 
       ffprobe.on('error', function(err) {
         callback(err);

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -209,8 +209,9 @@ FfmpegCommand.getAvailableFormats = function(callback) {
 
 require('./ffprobe')(FfmpegCommand.prototype);
 
-FfmpegCommand.ffprobe = function(file, callback) {
-  (new FfmpegCommand(file)).ffprobe(callback);
+FfmpegCommand.ffprobe = function(file) {
+  var instance = new FfmpegCommand(file);
+  instance.ffprobe.apply(instance, Array.prototype.slice.call(arguments, 1));
 };
 
 /* Add processing recipes */

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -77,6 +77,19 @@ describe('Metadata', function() {
     });
   });
 
+  it('should provide ffprobe extradata_hash in stream information', function(done) {
+    Ffmpeg.ffprobe(this.testfile, ['-show_data_hash', 'sha256'], function(err, data) {
+      testhelper.logError(err);
+      assert.ok(!err);
+
+      ('streams' in data).should.equal(true);
+      Array.isArray(data.streams).should.equal(true);
+      data.streams.length.should.equal(1);
+      data.streams[0].extradata_hash.should.equal('SHA256:837443060e4e47c395b2a817161207395cf0e96545f7d4757c316ea6162cd71d');
+      done();
+    });
+  });
+
   it('should return ffprobe errors', function(done) {
     Ffmpeg.ffprobe('/path/to/missing/file', function(err) {
       assert.ok(!!err);

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -77,15 +77,15 @@ describe('Metadata', function() {
     });
   });
 
-  it('should provide ffprobe extradata_hash in stream information', function(done) {
-    Ffmpeg.ffprobe(this.testfile, ['-show_data_hash', 'sha256'], function(err, data) {
+  it('should provide ffprobe stream information with units', function(done) {
+    Ffmpeg.ffprobe(this.testfile, ['-unit'], function(err, data) {
       testhelper.logError(err);
       assert.ok(!err);
 
       ('streams' in data).should.equal(true);
       Array.isArray(data.streams).should.equal(true);
       data.streams.length.should.equal(1);
-      data.streams[0].extradata_hash.should.equal('SHA256:837443060e4e47c395b2a817161207395cf0e96545f7d4757c316ea6162cd71d');
+      data.streams[0].bit_rate.should.equal('322427 bit/s');
       done();
     });
   });


### PR DESCRIPTION
This PR addresses #381. It would allow users to pass additional output options along with the default `-show_streams` and `-show_format` options. It would require users that wish to use it to call `ffprobe` this way though:

```js
ffmpeg('/path/to/file').outputOptions(...).ffprobe(function(err, metadata) { ... });
```