### PR TITLE
Ensure `codecData` is emitted for input streams

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -300,7 +300,17 @@ var utils = module.exports = {
       codecObject.video_details = video;
     }
 
-    var codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderr);
+    var streamInputs = command._inputs.filter(function(input) {
+      return input.isStream;
+    });
+
+    var codecInfoPassed = false;
+    if (streamInputs.length === 0) {
+      codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderr);
+    } else {
+      codecInfoPassed = /[\r\n]+Output #/.test(stderr);
+    }
+
     if (codecInfoPassed) {
       command.emit('codecData', codecObject);
       command._codecDataSent = true;

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -353,6 +353,31 @@ describe('Processor', function() {
         .saveToFile(testFile);
     });
 
+    it('should report codec data through \'codecData\' event for input streams', function(done) {
+      this.timeout(60000);
+      var testFile = path.join(__dirname, 'assets', 'testConvertFromStreamToFileCodecData.flv');
+      this.files.push(testFile);
+
+      var receivedCodecData = false;
+      var instream = fs.createReadStream(this.testfile);
+      this.getCommand({ source: instream, logger: testhelper.logger })
+        .usingPreset('flashvideo')
+        .on('error', function(err, stdout, stderr) {
+          testhelper.logError(err, stdout, stderr);
+          assert.ok(!err);
+        })
+        .on('codecData', function(data) {
+          receivedCodecData = true;
+          data.should.have.property('audio');
+          data.should.have.property('video');
+        })
+        .on('end', function() {
+          assert(receivedCodecData);
+          done();
+        })
+        .saveToFile(testFile);
+    });
+
     it('should report progress through \'progress\' event', function(done) {
       this.timeout(60000);
 


### PR DESCRIPTION
I noticed that codecData is never triggered if you use an input stream because of this code in `ffmpeg.c`:

```
     if (stdin_interaction) {
         av_log(NULL, AV_LOG_INFO, "Press [q] to stop, [?] for help\n");
     }
```

This patch adds an alternative check for `^Output #` to see if `codecData` should be emitted if there is at least one input stream.