### PR TITLE
Add duration fallback when computing timemarks

### DIFF
--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -190,6 +190,9 @@ module.exports = function recipes(proto) {
               }
 
               var duration = Number(vstream.duration);
+              if (isNaN(duration)) {
+                duration = Number(meta.format.duration);
+              }
 
               if (isNaN(duration)) {
                 return next(new Error('Could not get input duration, please specify fixed timemarks'));


### PR DESCRIPTION
@njoyard this PR addresses the fallback you and @inverizzie talked about yesterday. 

When the video stream is present, but the duration is reported to be "N/A", it should be able to get the duration from `meta.format.duration`. 