### PR TITLE
Fixed screenshot bug

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -149,7 +149,7 @@ module.exports = function(proto) {
           var data = parseFfprobeOutput(stdout);
 
           // Handle legacy output with "TAG:x" and "DISPOSITION:x" keys
-          [data.format].concat(data.streams).forEach(function(target) {
+          [data].concat(data.streams).forEach(function(target) {
             var legacyTagKeys = Object.keys(target).filter(legacyTag);
 
             if (legacyTagKeys.length) {


### PR DESCRIPTION
I was getting an error when trying to generate any screenshot

/opt/message-api-server/node_modules/fluent-ffmpeg/lib/ffprobe.js:154
            var legacyTagKeys = Object.keys(target).filter(legacyTag);
                                       ^
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at /opt/message-api-server/node_modules/fluent-ffmpeg/lib/ffprobe.js:154:40
    at Array.forEach (native)
    at handleExit (/opt/message-api-server/node_modules/fluent-ffmpeg/lib/ffprobe.js:152:46)
    at Socket.<anonymous> (/opt/message-api-server/node_modules/fluent-ffmpeg/lib/ffprobe.js:211:9)
    at Socket.emit (events.js:117:20)
    at Pipe.close (net.js:466:12)
