### PR TITLE
Fix for #422, (cross-platform) using node-which

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 
 var exec = require('child_process').exec;
 var isWindows = require('os').platform().match(/win(32|64)/);
+var which = require('which');
 
 var nlRegexp = /\r\n|\r|\n/g;
 var streamRegexp = /^\[?(.*?)\]?$/;
@@ -216,19 +217,13 @@ var utils = module.exports = {
       return callback(null, whichCache[name]);
     }
 
-    var cmd = 'which ' + name;
-    if (isWindows) {
-      cmd = 'where ' + name + '.exe';
-    }
-
-    exec(cmd, function(err, stdout) {
+    which(name, function(err, result){
       if (err) {
         // Treat errors as not found
-        callback(null, whichCache[name] = '');
-      } else {
-        callback(null, whichCache[name] = stdout.trim());
+        return callback(null, whichCache[name] = '');
       }
-    });
+      callback(null, whichCache[name] = result);
+    })
   },
 
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jsdoc": "latest"
   },
   "dependencies": {
-    "async": ">=0.2.9"
+    "async": ">=0.2.9",
+    "which": "^1.1.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Fix for #422, (cross-platform) using node-which for executable path finding