### PR TITLE
Testing with node 0.12 instead of 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ matrix:
     - os: linux
       env: NODE_VERSION=0.10
     - os: linux
-      env: NODE_VERSION=0.11
+      env: NODE_VERSION=0.12
 script:
   - tools/test-travis.sh


### PR DESCRIPTION
Travis has had Node 0.12 for a while, so it's probably better to test with that (until v4 comes out next month or so).

Travis wouldn't run the tests on my fork because of setuid issues, so if the tests fail for this PR, we'll know why.