### PR TITLE
fixed ffprobe parsing of sub-sections, reverted #412

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -13,16 +13,16 @@ function parseFfprobeOutput(out) {
     streams: []
   };
 
-  function parseBlock() {
+  function parseBlock(name) {
     var data = {};
 
     var line = lines.shift();
     while (line) {
-      if (line.match(/^\[\//)) {
+      if (line.toLowerCase() == '[/'+name+']') {
         return data;
       } else if (line.match(/^\[/)) {
-        lines.unshift(line);
-        return data;
+        line = lines.shift();
+        continue;
       }
 
       var kv = line.match(/^([^=]+)=(.*)$/);
@@ -43,10 +43,10 @@ function parseFfprobeOutput(out) {
   var line = lines.shift();
   while (line) {
     if (line.match(/^\[stream/i)) {
-      var stream = parseBlock();
+      var stream = parseBlock('stream');
       data.streams.push(stream);
     } else if (line.toLowerCase() === '[format]') {
-      data.format = parseBlock();
+      data.format = parseBlock('format');
     }
 
     line = lines.shift();
@@ -162,7 +162,7 @@ module.exports = function(proto) {
           var data = parseFfprobeOutput(stdout);
 
           // Handle legacy output with "TAG:x" and "DISPOSITION:x" keys
-          [data].concat(data.streams).forEach(function(target) {
+          [data.format].concat(data.streams).forEach(function(target) {
             var legacyTagKeys = Object.keys(target).filter(legacyTag);
 
             if (legacyTagKeys.length) {


### PR DESCRIPTION
As discussed in #412, 

The merged fix #412  removed the error by disabling the parsing of legacy `TAG` and `DISPOSITION` properties of the extracted `ffprobe` data, that raised an exception when `data.format` was undefined.

The actual problem was an improper parsing of  sub-sections, within the `[STREAM]` sections, tricking the parser into stoping before it encountered the `[FORMAT]` section, leading to the undefined `data.format`.

With this fix, the subsection(s) will now be parsed has top-level parent properties (eg: [STREAM])
Reverted #412, because is was removing a feature (tags/disposition grouping) only for the "format" section, not the "streams", making the whole output inconsistent.

PS: Much thanks for the lib, ffmpeg is full of its own horrors and oddities, and I can't begin to imagine how much work must have gone into making it fluent. 

Cheers

