### PR TITLE
added check for undefined data.format

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -52,6 +52,7 @@ function parseFfprobeOutput(out) {
     line = lines.shift();
   }
 
+  if (data.format == undefined) data.format = {};
   return data;
 }
 


### PR DESCRIPTION
For some reason data.format was undefined after calling parseFfprobeOutput in ffprobe.js, so calling Object.keys on it was throwing an error.