### PR TITLE
fixed issue with empty lines in parseFfprobeOutput

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -17,7 +17,7 @@ function parseFfprobeOutput(out) {
     var data = {};
 
     var line = lines.shift();
-    while (line) {
+    while (line != undefined) {
       if (line.toLowerCase() == '[/'+name+']') {
         return data;
       } else if (line.match(/^\[/)) {
@@ -41,7 +41,7 @@ function parseFfprobeOutput(out) {
   }
 
   var line = lines.shift();
-  while (line) {
+  while (line != undefined) {
     if (line.match(/^\[stream/i)) {
       var stream = parseBlock('stream');
       data.streams.push(stream);


### PR DESCRIPTION
Sometimes the ffprobe output would include empty lines, which would fail the while(line) checks, so I changed them to while(line != undefined).