### PR TITLE
Emit stderr event when FFmpeg outputs to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,17 @@ ffmpeg('/path/to/file.avi')
   });
 ```
 
+#### 'stderr': FFmpeg output
+
+The `stderr` event is emitted every time FFmpeg outputs a line to `stderr`.  It is emitted with a string containing the line of stderr (minus trailing new line characters).
+
+```js
+ffmpeg('/path/to/file.avi')
+  .on('stderr', function(stderrLine) {
+    console.log('Stderr output: ' + stderrLine);
+  });
+```
+
 #### 'error': transcoding error
 
 The `error` event is emitted when an error occurs when running ffmpeg or when preparing its execution.  It is emitted with an error object as an argument.  If the error happened during ffmpeg execution, listeners will also receive two additional arguments containing ffmpegs stdout and stderr.

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var async = require('async');
 var utils = require('./utils');
 
+var nlRegexp = /\r\n|\r|\n/g;
 
 /*
  *! Processor methods
@@ -45,6 +46,13 @@ module.exports = function(proto) {
    * @param {Number} progress.targetSize current output file size
    * @param {String} progress.timemark current video timemark
    * @param {Number} [progress.percent] processing progress (may not be available depending on input)
+   */
+
+  /**
+   * Emitted when ffmpeg outputs to stderr
+   *
+   * @event FfmpegCommand#stderr
+   * @param {String} line stderr output line
    */
 
   /**
@@ -426,6 +434,7 @@ module.exports = function(proto) {
       // Run ffmpeg
       var stdout = null;
       var stderr = '';
+      var stderrBuffer = '';
       self._spawnFfmpeg(
         args,
 
@@ -459,6 +468,7 @@ module.exports = function(proto) {
             processTimer = setTimeout(function() {
               var msg = 'process ran into a timeout (' + self.options.timeout + 's)';
 
+              stderr += stderrBuffer;
               emitEnd(new Error(msg), stdout, stderr);
               ffmpegProc.kill();
             }, self.options.timeout * 1000);
@@ -498,7 +508,23 @@ module.exports = function(proto) {
           // Process ffmpeg stderr data
           self._codecDataSent = false;
           ffmpegProc.stderr.on('data', function (data) {
-            stderr += data;
+            // Split stderr output into lines
+            data = stderrBuffer + data;
+
+            var match = data.match(/^([\s\S]*)(?:\r\n|\r|\n)([^\n\r]*)$/);
+            if (match) {
+              data = match[1];
+              stderrBuffer = match[2];
+            } else {
+              stderrBuffer = data;
+              return;
+            }
+
+            var lines = data.split(nlRegexp);
+            lines.forEach(function(line) {
+              stderr += line + '\n';
+              if (self.listeners('stderr').length) self.emit('stderr', line);
+            });
 
             if (!self._codecDataSent && self.listeners('codecData').length) {
               utils.extractCodecData(self, stderr);
@@ -518,6 +544,8 @@ module.exports = function(proto) {
 
         function endCB(err) {
           delete self.ffmpegProc;
+
+          stderr += stderrBuffer;
 
           if (err) {
             if (err.message.match(/ffmpeg exited with code/)) {


### PR DESCRIPTION
As discussed in #463, this PR adds an event `stderr` which is emitted whenever FFmpeg outputs a line to stderr.

I tried to regenerate the docs, but it seems they are already out of sync with the code.