### PR TITLE
FIX stderr variable increasing to infinite string on livestreaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The following options are available:
 * `preset` or `presets`: directory to load module presets from (defaults to the `lib/presets` directory in fluent-ffmpeg tree)
 * `niceness` or `priority`: ffmpeg niceness value, between -20 and 20; ignored on Windows platforms (defaults to 0)
 * `logger`: logger object with `debug()`, `info()`, `warn()` and `error()` methods (defaults to no logging)
+* `outputLineLimit`: limit the lines stored in variable `stderr` to reduce cpu load on regex operations (especially on
+livestreaming, that causes the `stderr` variable to increase without limit); the first `outputLineLimit` lines are kept and the
+last line gets overwritten `on 'data'` if linelimit has been reached
 
 
 ### Specifying inputs

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -25,6 +25,7 @@ var ARGLISTS = ['_global', '_audio', '_audioFilters', '_video', '_videoFilters',
  * @param {String} [options.presets="fluent-ffmpeg/lib/presets"] directory to load presets from
  * @param {String} [options.preset="fluent-ffmpeg/lib/presets"] alias for `presets`
  * @param {Number} [options.timeout=<no timeout>] ffmpeg processing timeout in seconds
+ * @param {Number} [options.outputLineLimit=0] limit the number of lines appended to stderr var (i.E. for livestreams)
  * @param {String|ReadableStream} [options.source=<no input>] alias for the `input` parameter
  */
 function FfmpegCommand(input, options) {
@@ -63,6 +64,7 @@ function FfmpegCommand(input, options) {
   // Set default option values
   options.presets = options.presets || options.preset || path.join(__dirname, 'presets');
   options.niceness = options.niceness || options.priority || 0;
+  options.outputLineLimit = options.outputLineLimit || 0;
 
   // Save options
   this.options = options;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -498,10 +498,23 @@ module.exports = function(proto) {
           // Process ffmpeg stderr data
           self._codecDataSent = false;
           ffmpegProc.stderr.on('data', function (data) {
+            // there is no need to append the new data to stderr value every time, this
+            // increases the stderr string (especially in live streaming processes) very fast and makes upcoming
+            // regex operations on this string cputime-expensive (like in utils::extractProgress).
+            // So if utils.extractProgress detect more than 50 lines the stderr value has to be reset
+            if (self.parseLastlineOnly){
+               stderr = '';
+            }
             stderr += data;
 
             if (!self._codecDataSent && self.listeners('codecData').length) {
-              utils.extractCodecData(self, stderr);
+              //if stderr has reaches 50 lines, it will only keep the last lines sent on 'data'
+              //but the first 50 lines are stored in the process-var processStartData, so we use them instead
+              if (self.parseLastlineOnly) {
+                  utils.extractCodecData(self, self.processStartData);
+              }else{
+                  utils.extractCodecData(self, stderr);
+              }
             }
 
             if (self.listeners('progress').length) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -498,23 +498,14 @@ module.exports = function(proto) {
           // Process ffmpeg stderr data
           self._codecDataSent = false;
           ffmpegProc.stderr.on('data', function (data) {
-            // there is no need to append the new data to stderr value every time, this
-            // increases the stderr string (especially in live streaming processes) very fast and makes upcoming
-            // regex operations on this string cputime-expensive (like in utils::extractProgress).
-            // So if utils.extractProgress detect more than 50 lines the stderr value has to be reset
-            if (self.parseLastlineOnly){
-               stderr = '';
+
+            if (self.lineLimitReached){
+                stderr = self.linesBeforeLimit
             }
             stderr += data;
 
             if (!self._codecDataSent && self.listeners('codecData').length) {
-              //if stderr has reaches 50 lines, it will only keep the last lines sent on 'data'
-              //but the first 50 lines are stored in the process-var processStartData, so we use them instead
-              if (self.parseLastlineOnly) {
-                  utils.extractCodecData(self, self.processStartData);
-              }else{
-                  utils.extractCodecData(self, stderr);
-              }
+              utils.extractCodecData(self, stderr);
             }
 
             if (self.listeners('progress').length) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -313,6 +313,11 @@ var utils = module.exports = {
    */
   extractProgress: function(command, stderr, duration) {
     var lines = stderr.split(nlRegexp);
+    if (lines.length >= 50){
+        command.parseLastlineOnly = true; //parse last lines only to reduce cpu load
+        //keep the first 50 lines in a variable if event 'codecData' is added dynamically
+        command.processStartData = stderr;
+    }
     var lastline = lines[lines.length - 2];
     var progress;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -313,11 +313,6 @@ var utils = module.exports = {
    */
   extractProgress: function(command, stderr, duration) {
     var lines = stderr.split(nlRegexp);
-    if (lines.length >= 50){
-        command.parseLastlineOnly = true; //parse last lines only to reduce cpu load
-        //keep the first 50 lines in a variable if event 'codecData' is added dynamically
-        command.processStartData = stderr;
-    }
     var lastline = lines[lines.length - 2];
     var progress;
 
@@ -338,6 +333,12 @@ var utils = module.exports = {
       // calculate percent progress using duration
       if (duration && duration > 0) {
         ret.percent = (utils.timemarkToSeconds(ret.timemark) / duration) * 100;
+      }
+      if (lines.length >= command.options.outputLineLimit && command.options.outputLineLimit > 0){
+          //flag for processor
+          command.lineLimitReached = true;
+          // keep lines defined in outputLineLimit to use the first lines for i.E. codecData event
+          command.linesBeforeLimit = lines.slice(0,command.options.outputLineLimit - 1).join("\n");
       }
 
       command.emit('progress', ret);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -338,7 +338,7 @@ var utils = module.exports = {
           //flag for processor
           command.lineLimitReached = true;
           // keep lines defined in outputLineLimit to use the first lines for i.E. codecData event
-          command.linesBeforeLimit = lines.slice(0,command.options.outputLineLimit - 1).join("\n");
+          command.linesBeforeLimit = lines.slice(0,command.options.outputLineLimit - 1).join("\n") + "\n";
       }
 
       command.emit('progress', ret);


### PR DESCRIPTION
The var 'stderr' appends all data, that comes on process event on 'data'. That causes a very long string on livestreaming, since 3-5 lines are added per second.

On the on 'progress' event, there are RegEx made on this string and i noticed, that this causes high cpu load on long strings, especially the raspberry pi has a cpuload of 100% after 2-3 hours of livestreaming with the fluent ffmpeg module. A v8 dump told me, that the load is caused by javascript RegEx method calls, so i started to search for the reason. 

I changed the code to only use the last lines of stderr if 50 lines of stderr output have been reached. Since the codecData is sent on these 50 lines of stderr output, i store the first 50 lines in an extra process-variable, to make dynamic adding of the 'codecData' event also possible. 

The result on my raspberry pi is, that the fluent-ffmpeg prcoess does not increase the cpu-load any more. 