### PR TITLE
Update thumbnail.js so as to not confuse people

### DIFF
--- a/examples/thumbnails.js
+++ b/examples/thumbnails.js
@@ -4,8 +4,11 @@ var proc = ffmpeg('/path/to/your_movie.avi')
   // set the size of your thumbnails
   .size('150x100')
   // setup event handlers
-  .on('end', function(files) {
-    console.log('screenshots were saved as ' + files.join(', '));
+  .on('filenames', function(filenames) {
+    console.log('screenshots are ' + filenames.join(', '));
+  })
+  .on('end', function() {
+    console.log('screenshots were saved);
   })
   .on('error', function(err) {
     console.log('an error happened: ' + err.message);

--- a/examples/thumbnails.js
+++ b/examples/thumbnails.js
@@ -8,7 +8,7 @@ var proc = ffmpeg('/path/to/your_movie.avi')
     console.log('screenshots are ' + filenames.join(', '));
   })
   .on('end', function() {
-    console.log('screenshots were saved);
+    console.log('screenshots were saved');
   })
   .on('error', function(err) {
     console.log('an error happened: ' + err.message);


### PR DESCRIPTION
To my knowledge, the `end` event doesn't give us the files as arguments anymore. 

I just added the `filenames` event to the example.