### PR TITLE
fix ffmpeg 2.8 ffprobe handling

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -10,7 +10,8 @@ function legacyDisposition(key) { return key.match(/^DISPOSITION:/); }
 function parseFfprobeOutput(out) {
   var lines = out.split(/\r\n|\r|\n/);
   var data = {
-    streams: []
+    streams: [],
+    format: {}
   };
 
   function parseBlock(name) {


### PR DESCRIPTION
When no [format] line in ffprobe output I get the following error:
```
Users/gyand/Work/yam/yam_editor/node_modules/fluent-ffmpeg/lib/ffprobe.js:153
            var legacyTagKeys = Object.keys(target).filter(legacyTag);
                                       ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (native)
    at /Users/gyand/Work/yam/yam_editor/node_modules/fluent-ffmpeg/lib/ffprobe.js:153:40
    at Array.forEach (native)
    at handleExit (/Users/gyand/Work/yam/yam_editor/node_modules/fluent-ffmpeg/lib/ffprobe.js:152:46)
    at ChildProcess.<anonymous> (/Users/gyand/Work/yam/yam_editor/node_modules/fluent-ffmpeg/lib/ffprobe.js:190:11)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
```