### PR TITLE
put size attr in takeScreenshots instead of using .size() in thumbnails.js

### DIFF
--- a/examples/thumbnails.js
+++ b/examples/thumbnails.js
@@ -1,8 +1,6 @@
 var ffmpeg = require('../index');
 
 var proc = ffmpeg('/path/to/your_movie.avi')
-  // set the size of your thumbnails
-  .size('150x100')
   // setup event handlers
   .on('filenames', function(filenames) {
     console.log('screenshots are ' + filenames.join(', '));
@@ -13,5 +11,5 @@ var proc = ffmpeg('/path/to/your_movie.avi')
   .on('error', function(err) {
     console.log('an error happened: ' + err.message);
   })
-  // take 2 screenshots at predefined timemarks
-  .takeScreenshots({ count: 2, timemarks: [ '00:00:02.000', '6' ] }, '/path/to/thumbnail/folder');
+  // take 2 screenshots at predefined timemarks and size
+  .takeScreenshots({ count: 2, timemarks: [ '00:00:02.000', '6' ], size: '150x100' }, '/path/to/thumbnail/folder');


### PR DESCRIPTION
Documentation says using .size() for thumbnails is deprecated. Updating example file to reflect this.