### PR TITLE
Options to not capture stderr/stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,17 @@ ffmpeg('/path/to/file.avi')
   });
 ```
 
+#### 'stderr': FFmpeg output
+
+The `stderr` event is emitted every time FFmpeg outputs a line to `stderr`.  It is emitted with a string containing the line of stderr (minus trailing new line characters).
+
+```js
+ffmpeg('/path/to/file.avi')
+  .on('stderr', function(stderrLine) {
+    console.log('Stderr output: ' + stderrLine);
+  });
+```
+
 #### 'error': transcoding error
 
 The `error` event is emitted when an error occurs when running ffmpeg or when preparing its execution.  It is emitted with an error object as an argument.  If the error happened during ffmpeg execution, listeners will also receive two additional arguments containing ffmpegs stdout and stderr.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The following options are available:
 * `preset` or `presets`: directory to load module presets from (defaults to the `lib/presets` directory in fluent-ffmpeg tree)
 * `niceness` or `priority`: ffmpeg niceness value, between -20 and 20; ignored on Windows platforms (defaults to 0)
 * `logger`: logger object with `debug()`, `info()`, `warn()` and `error()` methods (defaults to no logging)
-
+* `noStdout`: do not buffer and return `stdout` output (cannot be changed from `true` if output stream(s) are specified)
+* `noStderr`: do not buffer and return `stderr` output (you can still use the `stderr` event to get line-by-line `stderr` output in realtime)
 
 ### Specifying inputs
 

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -11,7 +11,8 @@ function parseFfprobeOutput(out) {
   var lines = out.split(/\r\n|\r|\n/);
   var data = {
     streams: [],
-    format: {}
+    format: {},
+    chapters: []
   };
 
   function parseBlock(name) {
@@ -46,6 +47,9 @@ function parseFfprobeOutput(out) {
     if (line.match(/^\[stream/i)) {
       var stream = parseBlock('stream');
       data.streams.push(stream);
+    } else if (line.match(/^\[chapter/i)) {
+      var chapter = parseBlock('chapter');
+      data.chapters.push(chapter);
     } else if (line.toLowerCase() === '[format]') {
       data.format = parseBlock('format');
     }
@@ -104,6 +108,7 @@ module.exports = function(proto) {
         }
         break;
     }
+
 
     if (index === null) {
       if (!this._currentInput) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var async = require('async');
 var utils = require('./utils');
 
+var nlRegexp = /\r\n|\r|\n/g;
 
 /*
  *! Processor methods
@@ -45,6 +46,13 @@ module.exports = function(proto) {
    * @param {Number} progress.targetSize current output file size
    * @param {String} progress.timemark current video timemark
    * @param {Number} [progress.percent] processing progress (may not be available depending on input)
+   */
+
+  /**
+   * Emitted when ffmpeg outputs to stderr
+   *
+   * @event FfmpegCommand#stderr
+   * @param {String} line stderr output line
    */
 
   /**
@@ -426,6 +434,7 @@ module.exports = function(proto) {
       // Run ffmpeg
       var stdout = null;
       var stderr = '';
+      var stderrBuffer = '';
       self._spawnFfmpeg(
         args,
 
@@ -459,6 +468,7 @@ module.exports = function(proto) {
             processTimer = setTimeout(function() {
               var msg = 'process ran into a timeout (' + self.options.timeout + 's)';
 
+              stderr += stderrBuffer;
               emitEnd(new Error(msg), stdout, stderr);
               ffmpegProc.kill();
             }, self.options.timeout * 1000);
@@ -498,7 +508,23 @@ module.exports = function(proto) {
           // Process ffmpeg stderr data
           self._codecDataSent = false;
           ffmpegProc.stderr.on('data', function (data) {
-            stderr += data;
+            // Split stderr output into lines
+            data = stderrBuffer + data;
+
+            var match = data.match(/^([\s\S]*)(?:\r\n|\r|\n)([^\n\r]*)$/);
+            if (match) {
+              data = match[1];
+              stderrBuffer = match[2];
+            } else {
+              stderrBuffer = data;
+              return;
+            }
+
+            var lines = data.split(nlRegexp);
+            lines.forEach(function(line) {
+              stderr += line + '\n';
+              if (self.listeners('stderr').length) self.emit('stderr', line);
+            });
 
             if (!self._codecDataSent && self.listeners('codecData').length) {
               utils.extractCodecData(self, stderr);
@@ -518,6 +544,8 @@ module.exports = function(proto) {
 
         function endCB(err) {
           delete self.ffmpegProc;
+
+          stderr += stderrBuffer;
 
           if (err) {
             if (err.message.match(/ffmpeg exited with code/)) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -433,8 +433,11 @@ module.exports = function(proto) {
 
       // Run ffmpeg
       var stdout = null;
-      var stderr = '';
+      var stderr = null;
       var stderrBuffer = '';
+      var stderrError = '';
+      var stderrCodec = '';
+
       self._spawnFfmpeg(
         args,
 
@@ -468,7 +471,6 @@ module.exports = function(proto) {
             processTimer = setTimeout(function() {
               var msg = 'process ran into a timeout (' + self.options.timeout + 's)';
 
-              stderr += stderrBuffer;
               emitEnd(new Error(msg), stdout, stderr);
               ffmpegProc.kill();
             }, self.options.timeout * 1000);
@@ -497,7 +499,7 @@ module.exports = function(proto) {
               emitEnd(new Error('Output stream error: ' + err.message));
               ffmpegProc.kill();
             });
-          } else {
+          } else if (!self.options.noStdout) {
             // Gather ffmpeg stdout
             stdout = '';
             ffmpegProc.stdout.on('data', function (data) {
@@ -506,8 +508,12 @@ module.exports = function(proto) {
           }
 
           // Process ffmpeg stderr data
+          if (!self.options.noStderr) stderr = '';
+
           self._codecDataSent = false;
           ffmpegProc.stderr.on('data', function (data) {
+            if (!self.options.noStderr) stderr += data;
+
             // Split stderr output into lines
             data = stderrBuffer + data;
 
@@ -520,24 +526,28 @@ module.exports = function(proto) {
               return;
             }
 
-            var lines = data.split(nlRegexp);
-            lines.forEach(function(line) {
-              stderr += line + '\n';
-              if (self.listeners('stderr').length) self.emit('stderr', line);
-            });
-
-            if (!self._codecDataSent && self.listeners('codecData').length) {
-              utils.extractCodecData(self, stderr);
-            }
-
+            var duration = 0;
             if (self.listeners('progress').length) {
-              var duration = 0;
-
               if (self._ffprobeData && self._ffprobeData.format && self._ffprobeData.format.duration) {
                 duration = Number(self._ffprobeData.format.duration);
               }
+            }
 
-              utils.extractProgress(self, stderr, duration);
+            var lines = data.split(nlRegexp);
+            lines.forEach(function(line) {
+              if (self.listeners('stderr').length) self.emit('stderr', line);
+              if (self.listeners('progress').length) utils.extractProgress(self, line, duration);
+              if (line.charAt(0) === ' ' || line.charAt(0) === '[') {
+                stderrError = '';
+              } else {
+                if (stderrError) stderrError += '\n';
+                stderrError += line;
+              }
+            });
+
+            if (!self._codecDataSent && self.listeners('codecData').length) {
+              stderrCodec += data + '\n';
+              utils.extractCodecData(self, stderrCodec);
             }
           });
         },
@@ -545,12 +555,14 @@ module.exports = function(proto) {
         function endCB(err) {
           delete self.ffmpegProc;
 
-          stderr += stderrBuffer;
-
           if (err) {
             if (err.message.match(/ffmpeg exited with code/)) {
               // Add ffmpeg error message
-              err.message += ': ' + utils.extractError(stderr);
+              if (stderrBuffer.charAt(0) === ' ' || stderrBuffer.charAt(0) === '[') {
+                if (stderrError) stderrError += '\n';
+                stderrError += stderrBuffer;
+              }
+              err.message += ': ' + stderrError;
             }
 
             emitEnd(err, stdout, stderr);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -295,7 +295,17 @@ var utils = module.exports = {
       codecObject.video_details = video;
     }
 
-    var codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderr);
+    var streamInputs = command._inputs.filter(function(input) {
+      return input.isStream;
+    });
+
+    var codecInfoPassed = false;
+    if (streamInputs.length === 0) {
+      codecInfoPassed = /Press (\[q\]|ctrl-c) to stop/.test(stderr);
+    } else {
+      codecInfoPassed = /[\r\n]+Output #/.test(stderr);
+    }
+
     if (codecInfoPassed) {
       command.emit('codecData', codecObject);
       command._codecDataSent = true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -321,9 +321,7 @@ var utils = module.exports = {
    * @param {Number} [duration=0] expected output duration in seconds
    * @private
    */
-  extractProgress: function(command, stderr, duration) {
-    var lines = stderr.split(nlRegexp);
-    var lastline = lines[lines.length - 2];
+  extractProgress: function(command, lastline, duration) {
     var progress;
 
     if (lastline) {
@@ -347,25 +345,5 @@ var utils = module.exports = {
 
       command.emit('progress', ret);
     }
-  },
-
-
-  /**
-   * Extract error message(s) from ffmpeg stderr
-   *
-   * @param {String} stderr ffmpeg stderr data
-   * @return {String}
-   * @private
-   */
-  extractError: function(stderr) {
-    // Only return the last stderr lines that don't start with a space or a square bracket
-    return stderr.split(nlRegexp).reduce(function(messages, message) {
-      if (message.charAt(0) === ' ' || message.charAt(0) === '[') {
-        return [];
-      } else {
-        messages.push(message);
-        return messages;
-      }
-    }, []).join('\n');
   }
 };

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -371,6 +371,31 @@ describe('Processor', function() {
         .saveToFile(testFile);
     });
 
+    it('should report codec data through \'codecData\' event for input streams', function(done) {
+      this.timeout(60000);
+      var testFile = path.join(__dirname, 'assets', 'testConvertFromStreamToFileCodecData.flv');
+      this.files.push(testFile);
+
+      var receivedCodecData = false;
+      var instream = fs.createReadStream(this.testfile);
+      this.getCommand({ source: instream, logger: testhelper.logger })
+        .usingPreset('flashvideo')
+        .on('error', function(err, stdout, stderr) {
+          testhelper.logError(err, stdout, stderr);
+          assert.ok(!err);
+        })
+        .on('codecData', function(data) {
+          receivedCodecData = true;
+          data.should.have.property('audio');
+          data.should.have.property('video');
+        })
+        .on('end', function() {
+          assert(receivedCodecData);
+          done();
+        })
+        .saveToFile(testFile);
+    });
+
     it('should report progress through \'progress\' event', function(done) {
       this.timeout(60000);
 


### PR DESCRIPTION
As discussed in #487, this PR adds options `noStderr` and `noStdout` to prevent caching of output.

Caching can cause memory problems when ffmpeg commands output a lot to `stderr` e.g. live streaming and filters like `bbox` which are very verbose.

This PR also improves performance in parsing stderr output for progress information (regardless of whether the `noStderr` option is true or not).