### PR TITLE
Add '' around complex filter

### DIFF
--- a/lib/options/custom.js
+++ b/lib/options/custom.js
@@ -196,7 +196,7 @@ module.exports = function(proto) {
       spec = [spec];
     }
 
-    this._complexFilters('-filter_complex', utils.makeFilterStrings(spec).join(';'));
+    this._complexFilters('-filter_complex', "\'" + utils.makeFilterStrings(spec).join(';') + "\'");
 
     if (Array.isArray(map)) {
       var self = this;


### PR DESCRIPTION
Without quotes around my `complex_filter`
Example:
This command fails when run manually or via nodejs:
`ffmpeg -i /home/ubuntu/twc-NOVA/lib/../master/lot.mp3 -y -filter_complex [0:a]volume=1.0[soft];[soft]amix=inputs=1:duration=longest -vn -loglevel debug /tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac`
With the output of:
```
Input #0, mp3, from '/home/ubuntu/twc-NOVA/lib/../master/lot.mp3':
  Metadata:
    genre           : Blues
  Duration: 00:00:40.29, start: 0.000000, bitrate: 192 kb/s
    Stream #0:0: Audio: mp3, 44100 Hz, stereo, s16p, 192 kb/s
At least one output file must be specified
[soft]amix=inputs=1:duration=longest: command not found
```

However, the same command with quote marks ('') works when run manually:
`ffmpeg -i /home/ubuntu/twc-NOVA/lib/../master/lot.mp3 -y -filter_complex '[0:a]volume=1.0[soft];[soft]amix=inputs=1:duration=longest' -vn -loglevel debug /tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac`
With the output of:
```
Splitting the commandline.
Reading option '-i' ... matched as input file with argument '/home/ubuntu/twc-NOVA/lib/../master/lot.mp3'.
Reading option '-y' ... matched as option 'y' (overwrite output files) with argument '1'.
Reading option '-filter_complex' ... matched as option 'filter_complex' (create a complex filtergraph) with argument '[0:a]volume=1.0[soft];[soft]amix=inputs=1:duration=longest'.
Reading option '-vn' ... matched as option 'vn' (disable video) with argument '1'.
Reading option '-loglevel' ... matched as option 'loglevel' (set logging level) with argument 'debug'.
Reading option '/tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac' ... matched as output file.
Finished splitting the commandline.
Parsing a group of options: global .
Applying option y (overwrite output files) with argument 1.
Applying option filter_complex (create a complex filtergraph) with argument [0:a]volume=1.0[soft];[soft]amix=inputs=1:duration=longest.
Applying option loglevel (set logging level) with argument debug.
Successfully parsed a group of options.
Parsing a group of options: input file /home/ubuntu/twc-NOVA/lib/../master/lot.mp3.
Successfully parsed a group of options.
Opening an input file: /home/ubuntu/twc-NOVA/lib/../master/lot.mp3.
[mp3 @ 0x2f56900] Format mp3 probed with size=16384 and score=51
[mp3 @ 0x2f56900] id3v2 ver:3 flags:00 len:6576
[mp3 @ 0x2f56900] Before avformat_find_stream_info() pos: 6586 bytes read:65664 seeks:2
[mp3 @ 0x2f56900] max_analyze_duration 5000000 reached at 5015510 microseconds
[mp3 @ 0x2f56900] Estimating duration from bitrate, this may be inaccurate
[mp3 @ 0x2f56900] After avformat_find_stream_info() pos: 129466 bytes read:163968 seeks:2 frames:194
Input #0, mp3, from '/home/ubuntu/twc-NOVA/lib/../master/lot.mp3':
  Metadata:
    genre           : Blues
  Duration: 00:00:40.29, start: 0.000000, bitrate: 192 kb/s
    Stream #0:0, 194, 1/14112000: Audio: mp3, 44100 Hz, stereo, s16p, 192 kb/s
Successfully opened the file.
Parsing a group of options: output file /tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac.
Applying option vn (disable video) with argument 1.
Successfully parsed a group of options.
Opening an output file: /tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac.
detected 16 logical cores
[Parsed_volume_0 @ 0x2f67120] Setting 'volume' to value '1.0'
[Parsed_amix_1 @ 0x2f67c00] Setting 'inputs' to value '1'
[Parsed_amix_1 @ 0x2f67c00] Setting 'duration' to value 'longest'
[graph 0 input from stream 0:0 @ 0x2f68360] Setting 'time_base' to value '1/44100'
[graph 0 input from stream 0:0 @ 0x2f68360] Setting 'sample_rate' to value '44100'
[graph 0 input from stream 0:0 @ 0x2f68360] Setting 'sample_fmt' to value 's16p'
[graph 0 input from stream 0:0 @ 0x2f68360] Setting 'channel_layout' to value '0x3'
[graph 0 input from stream 0:0 @ 0x2f68360] tb:1/44100 samplefmt:s16p samplerate:44100 chlayout:0x3
[audio format for output stream 0:0 @ 0x2f6a140] Setting 'sample_fmts' to value 's16'
[audio format for output stream 0:0 @ 0x2f6a140] Setting 'sample_rates' to value '96000|88200|64000|48000|44100|32000|24000|22050|16000|12000|11025|8000|7350'
Successfully opened the file.
[Parsed_volume_0 @ 0x2f67120] auto-inserting filter 'auto-inserted resampler 0' between the filter 'graph 0 input from stream 0:0' and the filter 'Parsed_volume_0'
[audio format for output stream 0:0 @ 0x2f6a140] auto-inserting filter 'auto-inserted resampler 1' between the filter 'Parsed_amix_1' and the filter 'audio format for output stream 0:0'
[AVFilterGraph @ 0x2f55f40] query_formats: 5 queried, 6 merged, 6 already done, 0 delayed
[auto-inserted resampler 0 @ 0x2f6ab80] ch:2 chl:stereo fmt:s16p r:44100Hz -> ch:2 chl:stereo fmt:flt r:44100Hz
[auto-inserted resampler 0 @ 0x2f6ab80] tb:0.000023 sample_rate:44100.000000 nb_channels:2.000000
[Parsed_volume_0 @ 0x2f67120] n:nan t:nan pts:nan precision:float volume:1.000000 volume_dB:0.000000
[Parsed_amix_1 @ 0x2f67c00] inputs:1 fmt:flt srate:44100 cl:stereo
[auto-inserted resampler 1 @ 0x2f456a0] ch:2 chl:stereo fmt:flt r:44100Hz -> ch:2 chl:stereo fmt:s16 r:44100Hz
Output #0, adts, to '/tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac':
  Metadata:
    genre           : Blues
    encoder         : Lavf55.43.100
    Stream #0:0, 0, 1/90000: Audio: aac (libvo_aacenc), 44100 Hz, stereo, s16, 128 kb/s
    Metadata:
      encoder         : Lavc55.66.101 libvo_aacenc
Stream mapping:
  Stream #0:0 (mp3) -> volume
  amix -> Stream #0:0 (libvo_aacenc)
Press [q] to stop, [?] for help
[output stream 0:0 @ 0x2f69de0] EOF on sink link output stream 0:0:default.
No more output streams to write to, finishing.
[libvo_aacenc @ 0x2f69960] Trying to remove 704 more samples than there are in the queue
size=     627kB time=00:00:40.08 bitrate= 128.1kbits/s
video:0kB audio:627kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.000000%
Input file #0 (/home/ubuntu/twc-NOVA/lib/../master/lot.mp3):
  Input stream #0:0 (audio): 1534 packets read (960284 bytes); 1534 frames decoded (1767168 samples);
  Total: 1534 packets (960284 bytes) demuxed
Output file #0 (/tmp/USGA00281US-a4985b33-d9e4-42bc-9b43-03c42b37d14e116218-20342-1l1l0c6/out.aac):
  Output stream #0:0 (audio): 1726 frames encoded (1767168 samples); 1728 packets muxed (641985 bytes);
  Total: 1728 packets (641985 bytes) muxed
1534 frames successfully decoded, 0 decoding errors
[AVIOContext @ 0x2f68400] Statistics: 0 seeks, 1728 writeouts
[AVIOContext @ 0x2f56020] Statistics: 993308 bytes read, 2 seeks
```

ffmpeg configuration:
```
ffmpeg version N-63893-gc69defd Copyright (c) 2000-2014 the FFmpeg developers
  built on Jul 16 2014 05:38:01 with gcc 4.6 (Debian 4.6.3-1)
  configuration: --prefix=/root/ffmpeg-static/64bit --extra-cflags='-I/root/ffmpeg-static/64bit/include -static' --extra-ldflags='-L/root/ffmpeg-static/64bit/lib -static' --extra-libs='-lxml2 -lexpat -lfreetype' --enable-static --disable-shared --disable-ffserver --disable-doc --enable-bzlib --enable-zlib --enable-postproc --enable-runtime-cpudetect --enable-libx264 --enable-gpl --enable-libtheora --enable-libvorbis --enable-libmp3lame --enable-gray --enable-libass --enable-libfreetype --enable-libopenjpeg --enable-libspeex --enable-libvo-aacenc --enable-libvo-amrwbenc --enable-version3 --enable-libvpx
  libavutil      52. 89.100 / 52. 89.100
  libavcodec     55. 66.101 / 55. 66.101
  libavformat    55. 43.100 / 55. 43.100
  libavdevice    55. 13.101 / 55. 13.101
  libavfilter     4.  8.100 /  4.  8.100
  libswscale      2.  6.100 /  2.  6.100
  libswresample   0. 19.100 /  0. 19.100
  libpostproc    52.  3.100 / 52.  3.100
```