### PR TITLE
Fixed empty line bug with rotation matrix

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -9,6 +9,11 @@ function legacyDisposition(key) { return key.match(/^DISPOSITION:/); }
 
 function parseFfprobeOutput(out) {
   var lines = out.split(/\r\n|\r|\n/);
+
+  lines = lines.filter(function (line) {
+    return line.length > 0;
+  });
+
   var data = {
     streams: [],
     format: {}


### PR DESCRIPTION
Had problems processing videos rotated 90 degrees. The ffprobe output had a blank line so i added a simple filter.