### PR TITLE
Added shell-option on processor.js

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -104,6 +104,7 @@ module.exports = function(proto) {
       endCB = processCB;
       processCB = options;
       options = {};
+      options.shell = true;
     }
 
     // Enable omitting processCB


### PR DESCRIPTION
I wanted to record 4 IP-streams with 4 instances of ffmpeg. Only 3 instances could be spawned successfully. 
When I added the option to add 'run' in the shell (because that's what this option does), the bug was fixed and I can record 4 IP-streams.