### PR TITLE
bugfix portrait video bug

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -8,7 +8,7 @@ function legacyTag(key) { return key.match(/^TAG:/); }
 function legacyDisposition(key) { return key.match(/^DISPOSITION:/); }
 
 function parseFfprobeOutput(out) {
-  var lines = out.split(/\r\n|\r|\n/);
+  var lines = out.split(/\r\n|\r|\n/).filter(Boolean);
 
   lines = lines.filter(function (line) {
     return line.length > 0;


### PR DESCRIPTION
here is the error, I'm trying to fix.

/var/app/current/node_modules/fluent-ffmpeg/lib/ffprobe.js:153
            var legacyTagKeys = Object.keys(target).filter(legacyTag);
                                       ^

TypeError: Cannot convert undefined or null to object
    at /var/app/current/node_modules/fluent-ffmpeg/lib/ffprobe.js:153:40
    at Array.forEach (native)
    at handleExit (/var/app/current/node_modules/fluent-ffmpeg/lib/ffprobe.js:152:46)
    at ChildProcess.<anonymous> (/var/app/current/node_modules/fluent-ffmpeg/lib/ffprobe.js:190:11)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)