### PR TITLE
Exposed stream errors to error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,8 @@ ffmpeg('/path/to/file.avi')
 
 The `error` event is emitted when an error occurs when running ffmpeg or when preparing its execution.  It is emitted with an error object as an argument.  If the error happened during ffmpeg execution, listeners will also receive two additional arguments containing ffmpegs stdout and stderr.
 
+If streams are used for input or output, any errors emitted from these streams will be passed through to this event, attached to the `error` as `inputStreamError` and `outputStreamError` for input and output streams respectively.
+
 **Warning**: you should _always_ set a handler for the `error` event, as node's default behaviour when an `error` event without any listeners is emitted is to output the error to the console and _terminate the program_.
 
 ```js

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -476,7 +476,7 @@ module.exports = function(proto) {
 
             // Handle output stream events
             outputStream.target.on('close', function() {
-              self.logger.debug('Output stream closed, scheduling kill for ffmpgeg process');
+              self.logger.debug('Output stream closed, scheduling kill for ffmpeg process');
 
               // Don't kill process yet, to give a chance to ffmpeg to
               // terminate successfully first  This is necessary because
@@ -489,7 +489,7 @@ module.exports = function(proto) {
             });
 
             outputStream.target.on('error', function(err) {
-              self.logger.debug('Output stream error, killing ffmpgeg process');
+              self.logger.debug('Output stream error, killing ffmpeg process');
               var reportingErr = new Error('Output stream error: ' + err.message);
               reportingErr.outputStreamError = err;
               emitEnd(reportingErr, stdoutRing.get(), stderrRing.get());

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -71,7 +71,7 @@ module.exports = function(proto) {
    * Emitted when an error happens when preparing or running a command
    *
    * @event FfmpegCommand#error
-   * @param {Error} error error object
+   * @param {Error} error error object, with optional properties 'inputStreamError' / 'outputStreamError' for errors on their respective streams
    * @param {String|null} stdout ffmpeg stdout, unless outputting to a stream
    * @param {String|null} stderr ffmpeg stderr
    */

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -490,7 +490,9 @@ module.exports = function(proto) {
 
             outputStream.target.on('error', function(err) {
               self.logger.debug('Output stream error, killing ffmpgeg process');
-              emitEnd(new Error('Output stream error: ' + err.message), stdoutRing.get(), stderrRing.get());
+              var reportingErr = new Error('Output stream error: ' + err.message);
+              reportingErr.outputStreamError = err;
+              emitEnd(reportingErr, stdoutRing.get(), stderrRing.get());
               ffmpegProc.kill();
             });
           }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -444,7 +444,9 @@ module.exports = function(proto) {
           // Pipe input stream if any
           if (inputStream) {
             inputStream.source.on('error', function(err) {
-              emitEnd(new Error('Input stream error: ' + err.message));
+              var reportingErr = new Error('Input stream error: ' + err.message);
+              reportingErr.inputStreamError = err;
+              emitEnd(reportingErr);
               ffmpegProc.kill();
             });
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -493,7 +493,7 @@ module.exports = function(proto) {
               var reportingErr = new Error('Output stream error: ' + err.message);
               reportingErr.outputStreamError = err;
               emitEnd(reportingErr, stdoutRing.get(), stderrRing.get());
-              ffmpegProc.kill();
+              ffmpegProc.kill('SIGKILL');
             });
           }
 

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -770,6 +770,48 @@ describe('Processor', function() {
         })
         .saveToFile(testFile);
     });
+    
+    it('should pass input stream errors through to error handler', function(done) {
+      var testFile = path.join(__dirname, 'assets', 'testConvertFromStream.avi')
+
+		const readError = new Error('Read Error')
+      const instream = new (require('stream').Readable)({
+        read() {
+  		    process.nextTick(() => this.emit('error', readError))
+		  }
+      })
+      
+      const command = this.getCommand({ source: instream, logger: testhelper.logger })
+
+      let startCalled = false
+      const self = this
+      
+      command
+          .usingPreset('divx')
+          .on('start', function() {
+          	startCalled = true
+            command.ffmpegProc.on('exit', function() {
+            	fs.exists(testFile, (exists) => {
+            		exists.should.be.false()
+						done()
+            	})
+            })
+          })
+          .on('error', function(err, stdout, stderr) {
+            self.saveOutput(stdout, stderr)
+            startCalled.should.be.true()
+            assert.ok(err)
+            err.message.indexOf('Input stream error: ').should.equal(0)
+			   assert.strictEqual(err.inputStreamError, readError)
+          })
+          .on('end', function(stdout, stderr) {
+            testhelper.logOutput(stdout, stderr)
+            console.log('end was called, expected a error')
+            assert.ok(false)
+            done()
+          })
+          .saveToFile(testFile)
+    })
   });
 
   describe('mergeToFile', function() {


### PR DESCRIPTION
Attached the `inputStreamError` and `outputStreamError` to the error passed through to the handlers so it can be inspected.

This is useful when using remote streams such as Google Cloud Storage ([`file.createReadStream()`](https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.1.0/storage/file?method=createReadStream)) and a caller wants to check if the remote `file` doesn't exist.

Also added tests.
