### PR TITLE
Allow progress events with streams

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -21,7 +21,12 @@ var nlRegexp = /\r\n|\r|\n/g;
  * @private
  */
 function runFfprobe(command) {
-  command.ffprobe(0, function(err, data) {
+  const inputProbeIndex = 0;
+  if (command._inputs[inputProbeIndex].isStream) {
+    // Don't probe input streams as this will consume them
+    return;
+  }
+  command.ffprobe(inputProbeIndex, function(err, data) {
     command._ffprobeData = data;
   });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -321,7 +321,6 @@ var utils = module.exports = {
    *
    * @param {FfmpegCommand} command event emitter
    * @param {String} stderrLine ffmpeg stderr data
-   * @param {Number} [duration=0] expected output duration in seconds
    * @private
    */
   extractProgress: function(command, stderrLine) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -333,7 +333,7 @@ var utils = module.exports = {
         frames: parseInt(progress.frame, 10),
         currentFps: parseInt(progress.fps, 10),
         currentKbps: progress.bitrate ? parseFloat(progress.bitrate.replace('kbits/s', '')) : 0,
-        targetSize: parseInt(progress.size, 10),
+        targetSize: parseInt(progress.size || progress.Lsize, 10),
         timemark: progress.time
       };
 


### PR DESCRIPTION
* Fixed bug with the last progress not being used correctly:
>[ffmpeg] frame=  812 fps=151 q=-1.0 **Lsize**=    1760kB time=00:00:32.52 bitrate= 443.3kbits/s speed=6.06x   

* Updated documentation from #568

* Don't allow input streams to be `ffprobe`d as this consumes the stream resulting in a failure when used by `ffmpeg`, but still allow the progress to be reported -it just won't have a duration / percentage.