### PR TITLE
Spawn ffprobe with optoins such as cwd

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -94,7 +94,7 @@ module.exports = function(proto) {
    *
    */
   proto.ffprobe = function() {
-    var input, index = null, options = [], callback;
+    var input, index = null, options = [], callback, spawnOptions = this.options;
 
     // the last argument should be the callback
     var callback = arguments[arguments.length - 1];
@@ -152,7 +152,7 @@ module.exports = function(proto) {
 
       // Spawn ffprobe
       var src = input.isStream ? 'pipe:0' : input.source;
-      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src));
+      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src), spawnOptions);
 
       if (input.isStream) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and


### PR DESCRIPTION
We have to set the working directory of the ffprobe process during probing HLS file because the HLS segment files have only relative path.

One sample usage:
const command = new FfmpegCommand(ilePathToMeu8, **{cwd: path.dirname(filePathToM3u8)**});
command.ffprobe((err, data) => {  // handle err/data here });