### PR TITLE
ffrobe param options is supposed to be a string array

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ setTimeout(function() {
 You can read metadata from any valid ffmpeg input file with the modules `ffprobe` method.
 
 ```js
-ffmpeg.ffprobe('/path/to/file.avi', function(err, metadata) {
+ffmpeg.ffprobe(['/path/to/file.avi'], function(err, metadata) {
     console.dir(metadata);
 });
 ```


### PR DESCRIPTION
Looks like for  ffprobe(options, cb) options is supposed to be a string array and not just a string. See  https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/b6b6ef35d3c09d6dc71a23ceb1fc25bccb7acb1f/lib/ffprobe.js#L119