### PR TITLE
Fixed rare error when something went wrong with ffprobe but no error …

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -239,23 +239,25 @@ module.exports = function(proto) {
       });
 
       // Handle stdout/stderr streams
-      ffprobe.stdout.on('data', function(data) {
-        stdout += data;
-      });
+      if ( ffprobe.stdout ){
+        ffprobe.stdout.on('data', function(data) {
+          stdout += data;
+        });
 
-      ffprobe.stdout.on('close', function() {
-        stdoutClosed = true;
-        handleExit();
-      });
+        ffprobe.stdout.on('close', function() {
+          stdoutClosed = true;
+          handleExit();
+        });
 
-      ffprobe.stderr.on('data', function(data) {
-        stderr += data;
-      });
+        ffprobe.stderr.on('data', function(data) {
+          stderr += data;
+        });
 
-      ffprobe.stderr.on('close', function() {
-        stderrClosed = true;
-        handleExit();
-      });
+        ffprobe.stderr.on('close', function() {
+          stderrClosed = true;
+          handleExit();
+        });
+      }
     });
   };
 };

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -248,7 +248,9 @@ module.exports = function(proto) {
           stdoutClosed = true;
           handleExit();
         });
+      }
 
+      if ( ffprobe.stderr ){
         ffprobe.stderr.on('data', function(data) {
           stderr += data;
         });

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -154,6 +154,10 @@ module.exports = function(proto) {
       var src = input.isStream ? 'pipe:0' : input.source;
       var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src));
 
+      // Check if we have ffprobe
+      if ( !ffprobe || !ffprobe.stdout || !ffprobe.stdin )
+      	return handleCallback( new Error('ffprobe process did not spawn ?') )
+
       if (input.isStream) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and
         // there seems to be no way hook in and close stdin before it throws.
@@ -238,28 +242,25 @@ module.exports = function(proto) {
         }
       });
 
-      // Handle stdout/stderr streams
-      if ( ffprobe.stdout ){
-        ffprobe.stdout.on('data', function(data) {
-          stdout += data;
-        });
+     // Handle stdout/stderr streams
+    ffprobe.stdout.on('data', function(data) {
+      stdout += data;
+    });
 
-        ffprobe.stdout.on('close', function() {
-          stdoutClosed = true;
-          handleExit();
-        });
-      }
+    ffprobe.stdout.on('close', function() {
+      stdoutClosed = true;
+      handleExit();
+    });
+  
+    ffprobe.stderr.on('data', function(data) {
+      stderr += data;
+    });
 
-      if ( ffprobe.stderr ){
-        ffprobe.stderr.on('data', function(data) {
-          stderr += data;
-        });
-
-        ffprobe.stderr.on('close', function() {
-          stderrClosed = true;
-          handleExit();
-        });
-      }
+    ffprobe.stderr.on('close', function() {
+      stderrClosed = true;
+      handleExit();
+    });
+      
     });
   };
 };


### PR DESCRIPTION
…was thrown

I've come across a case when ffprobe doesn't seem to initialize correctly or something (I still don't really know what's causing this, I had this while probing large batches of streams) and the script crashes when trying to emit the "stdout/stderr" streams events, because ffprobe.stdout is undefined.

I had no luck catching this error at a higher level, so that's why I'm submitting this quick fix because it was really blocking me.