### PR TITLE
add new functional: speed Up/Down video and audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,17 @@ Disables audio in the output and remove any previously set audio option.
 ffmpeg('/path/to/file.avi').noAudio();
 ```
 
+#### audioSpeed(): change audio speed
+
+**Aliases**: `withAudioSpeed()`.
+
+Speed Up/Down audio
+
+```js
+ffmpeg('/path/to/file.avi').audioSpeed(3);
+ffmpeg('/path/to/file.avi').audioSpeed(0.4);
+```
+
 #### audioCodec(codec): set audio codec
 
 **Aliases**: `withAudioCodec()`.
@@ -337,6 +348,17 @@ This method disables video output and removes any previously set video option.
 
 ```js
 ffmpeg('/path/to/file.avi').noVideo();
+```
+
+#### videoSpeed(): change video speed
+
+**Aliases**: `withVideoSpeed()`.
+
+Speed Up/Down video
+
+```js
+ffmpeg('/path/to/file.avi').videoSpeed(3);
+ffmpeg('/path/to/file.avi').videoSpeed(0.4);
 ```
 
 #### videoCodec(codec): set video codec

--- a/lib/options/audio.js
+++ b/lib/options/audio.js
@@ -114,6 +114,32 @@ module.exports = function(proto) {
 
 
   /**
+   * Set audio speed
+   *
+   * @method FfmpegCommand#audioSpeed
+   * @category Output
+   * @aliases withAudioSpeed,setAudioSpeed
+   *
+   * @param {String|Number} audioSpeed The value of the audio speed.
+   * @return FfmpegCommand
+   */
+  proto.withAudioSpeed =
+  proto.setAudioSpeed =
+  proto.audioSpeed = function(audioSpeed) {
+    if (audioSpeed > 2) {
+      this._currentOutput.audioFilters('atempo=2');
+      return this.audioSpeed(audioSpeed/2);
+    } else if (audioSpeed < 0.5) {
+      this._currentOutput.audioFilters('atempo=0.5');
+      return this.audioSpeed(audioSpeed/0.5);
+    }
+
+    this._currentOutput.audioFilters('atempo=' + audioSpeed);
+    return this;
+  };  
+
+
+  /**
    * Specify custom audio filter(s)
    *
    * Can be called both with one or many filters, or a filter array.

--- a/lib/options/videosize.js
+++ b/lib/options/videosize.js
@@ -251,6 +251,23 @@ module.exports = function(proto) {
 
 
   /**
+   * Set video speed
+   *
+   * @method FfmpegCommand#videoSpeed
+   * @category Output
+   * @aliases withVideoSpeed,setVideoSpeed
+   *
+   * @param {String|Number} videoSpeed The value of the video speed.
+   * @return FfmpegCommand
+   */
+  proto.withVideoSpeed =
+  proto.setVideoSpeed =
+  proto.videoSpeed = function(videoSpeed) {
+    this._currentOutput.sizeFilters('setpts=' + 1/videoSpeed + '*PTS');
+    return this;
+  };
+
+  /**
    * Enable auto-padding the output
    *
    * @method FfmpegCommand#autopad


### PR DESCRIPTION
Hi, I have noticed in package missing speed change functional, I have added new functional to change speed for video and audio, now you can speed up/down video and audio.

To understand my changes please look this:
https://trac.ffmpeg.org/wiki/How%20to%20speed%20up%20/%20slow%20down%20a%20video