### PR TITLE
Update deprecated function call

### DIFF
--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -326,19 +326,18 @@ module.exports = function recipes(proto) {
 
       // Create output directory
       function createDirectory(filenames, next) {
-        fs.exists(config.folder, function(exists) {
-          if (!exists) {
-            fs.mkdir(config.folder, function(err) {
-              if (err) {
-                next(err);
-              } else {
-                next(null, filenames);
-              }
-            });
-          } else {
-            next(null, filenames);
-          }
-        });
+        var exists = fs.existsSync(config.folder);
+        if (!exists) {
+          fs.mkdir(config.folder, function(err) {
+            if (err) {
+              next(err);
+            } else {
+              next(null, filenames);
+            }
+          });
+        } else {
+          next(null, filenames);
+        }
       }
     ], function runCommand(err, filenames) {
       if (err) {


### PR DESCRIPTION
Changed to synchronous version of `fs.exists()` because the asynchronous function is [deprecated](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback)
