### PR TITLE
Change from const to var to comply with 'use strict'

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -21,7 +21,7 @@ var nlRegexp = /\r\n|\r|\n/g;
  * @private
  */
 function runFfprobe(command) {
-  const inputProbeIndex = 0;
+  var inputProbeIndex = 0;
   if (command._inputs[inputProbeIndex].isStream) {
     // Don't probe input streams as this will consume them
     return;


### PR DESCRIPTION
Fixes #836 
Simply changed inputProbeIndex from const to var 👍 