### PR TITLE
Provide the process id when start

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -444,7 +444,7 @@ module.exports = function(proto) {
 
         function processCB(ffmpegProc, stdoutRing, stderrRing) {
           self.ffmpegProc = ffmpegProc;
-          self.emit('start', 'ffmpeg ' + args.join(' '));
+          self.emit('start', 'ffmpeg ' + args.join(' '), ffmpegProc.pid);
 
           // Pipe input stream if any
           if (inputStream) {


### PR DESCRIPTION
It will be nice if we could return the process id when a new command is executed!
I haven't add the process id to the event "end" but will be helpfull too.
i'm working on a application that require having access to process id, and i'm struggling finding the way to do it right now.