### PR TITLE
Add header() method to support HTTP/S Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,30 @@ ffmpeg()
   .mergeAdd('/path/to/input2.avi');
 ```
 
+### HTTP/S Headers
+
+If you need to configure the process with Authorization headers or some other custom header for remote storage locations such as Google Cloud Storage or AWS S3, you can pass those to the `headers()` method. This method accepts a string or array of strings representing HTTP/S headers. You can call this as many times as you'd like, it will just concatenate the entries. Headers are currently applied to all inputs within a command invocation. This method translates to the `--headers` flag on `ffmpeg` and `ffprobe`.
+
+Example usage with `ffmpeg` to save a file from Google Cloud Storage.
+
+```js
+ffmpeg()
+  .input('https://www.googleapis.com/storage/v1/b/my-private-bucket/o/my-file.mp4?alt=media')
+  .headers('Authorization: Bearer xyz123...')
+  .headers('X-My-Custom-Header: 1234')
+  .output('path/to/saved/file.mp4');
+```
+
+This feature is also available when probing a file with `ffprobe`.
+
+```js
+ffmpeg()
+  .input('https://www.googleapis.com/storage/v1/b/my-private-bucket/o/my-file.mp4?alt=media')
+  .headers(['Authorization: Bearer xyz123...', 'X-My-Custom-Header: 1234'])
+  .ffprobe((err, res) => {
+    ...
+  });
+```
 
 ### Input options
 

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -94,12 +94,12 @@ module.exports = function(proto) {
    *
    */
   proto.ffprobe = function() {
-    var input, index = null, options = [], callback;
+    var input, index = null, headers = [], options = [], callback;
 
     // the last argument should be the callback
     var callback = arguments[arguments.length - 1];
 
-    var ended = false
+    var ended = false;
     function handleCallback(err, data) {
       if (!ended) {
         ended = true;
@@ -122,7 +122,12 @@ module.exports = function(proto) {
         break;
     }
 
+    // Get headers
+    if (this._headers) {
+      headers = this._headers;
+    }
 
+    // Get input
     if (index === null) {
       if (!this._currentInput) {
         return handleCallback(new Error('No input specified'));
@@ -152,7 +157,8 @@ module.exports = function(proto) {
 
       // Spawn ffprobe
       var src = input.isStream ? 'pipe:0' : input.source;
-      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src));
+      var args = ['-show_streams', '-show_format'].concat(headers, options, src);
+      var ffprobe = spawn(path, args);
 
       if (input.isStream) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -161,6 +161,7 @@ FfmpegCommand.prototype.clone = function() {
 
 /* Add methods from options submodules */
 
+require('./options/headers')(FfmpegCommand.prototype);
 require('./options/inputs')(FfmpegCommand.prototype);
 require('./options/audio')(FfmpegCommand.prototype);
 require('./options/video')(FfmpegCommand.prototype);

--- a/lib/options/headers.js
+++ b/lib/options/headers.js
@@ -1,0 +1,70 @@
+/*jshint node:true*/
+'use strict';
+
+/**
+ * Checks header validity.
+ *
+ * Header is checked for spec, the name can contain a-z and a dash. The value
+ * can be any character. They should be separated by a colon. No spaces before
+ * colon.
+ *
+ * Ex:
+ * - `Authorization: Bearer y8s39...`
+ * - `X-My-Custom-Header: Custom Value`
+ *
+ * @param {String} header A string representation of a header.
+ */
+function isValidHeader(header) {
+  return header.match(/^[a-zA-Z-]*:.*/);
+}
+
+/**
+ * Headers
+ */
+module.exports = function(proto) {
+  /**
+   * Adds HTTP/S headers
+   *
+   * May be called multiple times to append more headers.
+   *
+   * Note: HTTP headers are added to command options before the input.
+   *
+   * @method FfmpegCommand#headers
+   * @category Headers
+   *
+   * @param {String|Array} headers A string or array of strings representing HTTP/S headers.
+   * @return FfmpegCommand
+   */
+  proto.headers = function(headers) {
+    if (!headers) {
+      return this;
+    }
+
+    // If headers param is a string...
+    if (!Array.isArray(headers) && typeof headers === 'string') {
+      // ...map it to an array.
+      headers = [headers];
+    }
+
+    if (Array.isArray(headers)) {
+      // Validate headers...
+      for(var i = 0; i < headers.length; i++) {
+        // If any new header is not valid, ignore this invocation.
+        if (!isValidHeader(headers[i])) {
+          return this;
+        }
+      }
+
+      // If headers are already set...
+      if (Array.isArray(this._headers) && this._headers[1]) {
+        // append new headers.
+        this._headers[1] = this._headers[1] + '\r\n' + headers.join('\r\n');
+      } else {
+        // Otherwise set initial headers.
+        this._headers = ['-headers', headers.join('\r\n')];
+      }
+    }
+
+    return this;
+  }
+}

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -224,6 +224,7 @@ module.exports = function(proto) {
    */
   proto._getArguments = function() {
     var complexFilters = this._complexFilters.get();
+    var headers = this._headers ? this._headers : [];
 
     var fileOutput = this._outputs.some(function(output) {
       return output.isFile;
@@ -236,6 +237,7 @@ module.exports = function(proto) {
 
           // For each input, add input options, then '-i <source>'
           return args.concat(
+            headers,
             input.options.get(),
             ['-i', source]
           );

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -236,6 +236,34 @@ describe('Command', function() {
     });
   });
 
+  describe('headers', function() {
+    it ('should apply a single string as headers argument', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .headers('Authorization: Bearer xyz123')
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+          var indexOfInput = args.indexOf('-i');
+          args.indexOf('-headers').should.above(-1).and.below(indexOfInput);
+          args.indexOf('Authorization: Bearer xyz123').should.above(-1).and.below(indexOfInput);
+          done();
+      });
+    });
+
+    it ('should apply an array of strings as headers argument', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .headers(['Authorization: Bearer xyz123', 'X-My-Custom-Heasder: 1234'])
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+          var indexOfInput = args.indexOf('-i');
+          args.indexOf('-headers').should.above(-1).and.below(indexOfInput);
+          args.indexOf('Authorization: Bearer xyz123\r\nX-My-Custom-Heasder: 1234').should.above(-1).and.below(indexOfInput);
+          done();
+      });
+    });
+  });
+
   describe('withInputFPS', function() {
     it('should apply the rate argument', function(done) {
       new Ffmpeg({ source: this.testfile, logger: testhelper.logger })


### PR DESCRIPTION
Headers are sometimes important for fetching source files from secure locations (i.e. Google Cloud Storage, AWS S3). This PR provides a clearcut method for adding HTTP headers with assurance that headers are applied in the right order on the `ffmpeg` and `ffprobe` commands.

* New `headers()` method added.
* README updated.
* Tests written.

`Examples`

*ffmpeg*
```js
ffmpeg()
  .input('https://www.googleapis.com/storage/v1/b/my-private-bucket/o/my-file.mp4?alt=media')
  .headers('Authorization: Bearer xyz123...')
  .headers('X-My-Custom-Header: 1234')
  .output('path/to/saved/file.mp4');
```

*ffprobe*
```js
ffmpeg()
  .input('https://www.googleapis.com/storage/v1/b/my-private-bucket/o/my-file.mp4?alt=media')
  .headers(['Authorization: Bearer xyz123...', 'X-My-Custom-Header: 1234'])
  .ffprobe((err, res) => {
    ...
  });
```