### PR TITLE
Check command has inputs

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -22,7 +22,7 @@ var nlRegexp = /\r\n|\r|\n/g;
  */
 function runFfprobe(command) {
   const inputProbeIndex = 0;
-  if (command._inputs[inputProbeIndex].isStream) {
+  if (command._inputs[inputProbeIndex] && command._inputs[inputProbeIndex].isStream) {
     // Don't probe input streams as this will consume them
     return;
   }


### PR DESCRIPTION
Fixed a bug where if the command didn't use .input() it wouldn't allow it to run