### PR TITLE
fix: options are not filtered rigorously

### DIFF
--- a/lib/options/custom.js
+++ b/lib/options/custom.js
@@ -110,7 +110,7 @@ module.exports = function(proto) {
     }
 
     this._currentOutput.options(options.reduce(function(options, option) {
-      var split = String(option).split(' ');
+      var split = String(option).trim().split(' ');
 
       if (doSplit && split.length === 2) {
         options.push(split[0], split[1]);


### PR DESCRIPTION
1. When there are spaces on sides of an option, an error will be triggered, and the error will not contain any useful information.