### PR TITLE
Fixed windows issue

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -158,7 +158,7 @@ module.exports = function(proto) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and
         // there seems to be no way hook in and close stdin before it throws.
         ffprobe.stdin.on('error', function(err) {
-          if (['ECONNRESET', 'EPIPE'].indexOf(err.code) >= 0) { return; }
+          if (['ECONNRESET', 'EPIPE', 'EOF'].indexOf(err.code) >= 0) { return; }
           handleCallback(err);
         });
 


### PR DESCRIPTION
Ignore "write EOF" errors for ffprobe

When using ffprobe with an input stream on Windows, a "write EOF" error was thrown.
If we add this error to the list of ignored errors, the metadata is successfully returned.