### PR TITLE
fix: progress not reported when "-loglevel +level" flag is used

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,8 +20,10 @@ var whichCache = {};
 function parseProgressLine(line) {
   var progress = {};
 
+  // Remove level prefix when "-loglevel +level" flag is used
+  line = line.replace(/^\[info\]/, '')
   // Remove all spaces after = and trim
-  line  = line.replace(/=\s+/g, '=').trim();
+  line = line.replace(/=\s+/g, '=').trim();
   var progressParts = line.split(' ');
 
   // Split every progress part by "=" to get key and value

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -457,6 +457,31 @@ describe('Processor', function() {
           .saveToFile(testFile);
     });
 
+    it('should report progress through \'progress\' event when \'-loglevel +level\' flag is used', function(done) {
+      this.timeout(60000);
+
+      var testFile = path.join(__dirname, 'assets', 'testOnProgress.avi');
+      var gotProgress = false;
+
+      this.files.push(testFile);
+
+      this.getCommand({ source: this.testfilebig, logger: testhelper.logger })
+          .on('progress', function() {
+            gotProgress = true;
+          })
+          .usingPreset('divx')
+          .addOption('-loglevel +level')
+          .on('error', function(err, stdout, stderr) {
+            testhelper.logError(err, stdout, stderr);
+            assert.ok(!err);
+          })
+          .on('end', function() {
+            gotProgress.should.equal(true);
+            done();
+          })
+          .saveToFile(testFile);
+    });
+
     it('should report start of ffmpeg process through \'start\' event', function(done) {
       this.timeout(60000);
 


### PR DESCRIPTION
When `-loglevel +level` flag is used, the output looks like so:

```
[info] frame= 1668 fps=0.0 q=-0.0 size=N/A time=00:00:55.90 bitrate=N/A speed= 112x    
[info] frame= 3191 fps=3187 q=-0.0 size=N/A time=00:01:46.70 bitrate=N/A speed= 107x    
[error] Error while decoding stream #0:0: Invalid data found when processing input
```

The leading `[info]` prevented `parseProgressLine(line)` from parsing.

https://github.com/riophae/node-fluent-ffmpeg/blob/d74149d0956091791c627a3e8c149c083be41210/lib/utils.js#L13-L41