### PR TITLE
Add readMetadata option for FfmpegCommand constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following options are available:
 * `niceness` or `priority`: ffmpeg niceness value, between -20 and 20; ignored on Windows platforms (defaults to 0)
 * `logger`: logger object with `debug()`, `info()`, `warn()` and `error()` methods (defaults to no logging)
 * `stdoutLines`: maximum number of lines from ffmpeg stdout/stderr to keep in memory (defaults to 100, use 0 for unlimited storage)
+* `readMetadata`: a boolean indicates whether to read metadata of inputs using ffprobe; video format and duration will not be available if this option is set to false (defaults to true)
 
 
 ### Specifying inputs

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -65,6 +65,7 @@ function FfmpegCommand(input, options) {
   options.stdoutLines = 'stdoutLines' in options ? options.stdoutLines : 100;
   options.presets = options.presets || options.preset || path.join(__dirname, 'presets');
   options.niceness = options.niceness || options.priority || 0;
+  options.readMetadata = 'readMetadata' in options ? options.readMetadata : true;
 
   // Save options
   this.options = options;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -286,7 +286,7 @@ module.exports = function(proto) {
    *
    * @method FfmpegCommand#_prepare
    * @param {Function} callback callback with signature (err, args)
-   * @param {Boolean} [readMetadata=false] read metadata before processing
+   * @param {Boolean} [readMetadata=true] read metadata before processing
    * @private
    */
   proto._prepare = function(callback, readMetadata) {
@@ -300,7 +300,7 @@ module.exports = function(proto) {
 
       // Read metadata if required
       function(cb) {
-        if (!readMetadata) {
+        if (readMetadata) {
           return cb();
         }
 
@@ -365,7 +365,7 @@ module.exports = function(proto) {
       }
     ], callback);
 
-    if (!readMetadata) {
+    if (readMetadata) {
       // Read metadata as soon as 'progress' listeners are added
 
       if (this.listeners('progress').length > 0) {
@@ -589,7 +589,7 @@ module.exports = function(proto) {
           }
         }
       );
-    });
+    }, self.options.readMetadata);
   };
 
 


### PR DESCRIPTION
There was a `readMetadata` param in `FfmpegCommand._prepare` but not used. I added it as an option in `FfmpegCommand` constructor so developers are able to disable probing before ffmpeg starts. By controlling whether to probe metadata, developers can:
- [x] reduce resource usage if reading metadata is not necessary.
- [x] solve the bug proposed in [Issue#737](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/737) (When ffmpeg runs in tcp/udp listen mode, the spawned ffprobe uses the same port and causes conflict).
- [x] several frames may be consumed by ffprobe if the input is a live stream.