### PR TITLE
small tweak on `run()` method

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -590,6 +590,8 @@ module.exports = function(proto) {
         }
       );
     });
+
+    return this;
   };
 
 


### PR DESCRIPTION
This enables the usage of:

```js
var command = ffmpeg()
  ...
  .run()

setTimeout(() => {
  command.kill()
}, 60000)
```