### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+
+
 before_install:
-  - sudo add-apt-repository ppa:sauce/ppa -y
-  - sudo apt-get update -q
-  - sudo apt-get install flvtool2 -y
-matrix:
+  - gem install flvtool2
+
+jobs:
   include:
     - os: linux
       env: NODE_VERSION=8
@@ -10,8 +11,10 @@ matrix:
       env: NODE_VERSION=10
     - os: linux
       env: NODE_VERSION=11
+
 script:
   - tools/test-travis.sh
+  
 addons:
   apt:
     packages:


### PR DESCRIPTION
Travis-CI has updated their YAML spec. Now, it's possible to define an "addon" and not use `before_install` which was causing the build to crash due to not finding `flvtool2` in the ubuntu repository

Fixes #955 