### PR TITLE
Update JSDoc for stdoutLines

### DIFF
--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -24,7 +24,7 @@ var ARGLISTS = ['_global', '_audio', '_audioFilters', '_video', '_videoFilters',
  * @param {Number} [options.priority=0] alias for `niceness`
  * @param {String} [options.presets="fluent-ffmpeg/lib/presets"] directory to load presets from
  * @param {String} [options.preset="fluent-ffmpeg/lib/presets"] alias for `presets`
- * @param {String} [options.stdoutLines=100] maximum lines of ffmpeg output to keep in memory, use 0 for unlimited
+ * @param {Number} [options.stdoutLines=100] maximum lines of ffmpeg output to keep in memory, use 0 for unlimited
  * @param {Number} [options.timeout=<no timeout>] ffmpeg processing timeout in seconds
  * @param {String|ReadableStream} [options.source=<no input>] alias for the `input` parameter
  */


### PR DESCRIPTION
stdoutLines should be a number, not a string

resolves: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/960