### PR TITLE
ffprobe: added EOF to the list of ignored errors

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -158,7 +158,7 @@ module.exports = function(proto) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and
         // there seems to be no way hook in and close stdin before it throws.
         ffprobe.stdin.on('error', function(err) {
-          if (['ECONNRESET', 'EPIPE'].indexOf(err.code) >= 0) { return; }
+          if (['ECONNRESET', 'EPIPE', 'EOF'].indexOf(err.code) >= 0) { return; }
           handleCallback(err);
         });
 


### PR DESCRIPTION
As reported in https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/601, there sometimes is an EOF error on ffprobe process close which prevent from retrieving the metadata even though they have been successfully extracted.