### PR TITLE
Support for gracefully exiting ffmpeg

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -439,7 +439,7 @@ module.exports = function(proto) {
           niceness: self.options.niceness,
           cwd: self.options.cwd,
           windowsHide: true
-        }, 
+        },
 
         function processCB(ffmpegProc, stdoutRing, stderrRing) {
           self.ffmpegProc = ffmpegProc;
@@ -655,6 +655,25 @@ module.exports = function(proto) {
       this.logger.warn('No running ffmpeg process, cannot send signal');
     } else {
       this.ffmpegProc.kill(signal || 'SIGKILL');
+    }
+
+    return this;
+  };
+
+  /**
+   * quit current ffmpeg process, if any
+   *
+   * @method FfmpegCommand#quit
+   * @category Processing
+   *
+   * @return FfmpegCommand
+   */
+  proto.quit = function(signal) {
+    if (!this.ffmpegProc) {
+      this.logger.warn('No running ffmpeg process, cannot quit');
+    } else {
+      this.ffmpegProc.stdin.setEncoding('utf-8');
+      this.ffmpegProc.stdin.write("q\n");
     }
 
     return this;

--- a/test/processor.test.js
+++ b/test/processor.test.js
@@ -365,6 +365,38 @@ describe('Processor', function() {
     });
   });
 
+
+  it('should gracefully quit the process with .quit', function(done) {
+    var testFile = path.join(__dirname, 'assets', 'testProcessQuit.avi');
+    this.files.push(testFile);
+
+    var ffmpegJob = this.getCommand({ source: this.testfilebig, logger: testhelper.logger })
+        .usingPreset('divx');
+
+    var startCalled = false;
+    var errorCalled = false;
+
+    ffmpegJob
+        .on('start', function() {
+          startCalled = true;
+          setTimeout(function() { ffmpegJob.quit(); }, 500);
+          ffmpegJob.ffmpegProc.on('exit', function() {
+            setTimeout(function() {
+              errorCalled.should.equal(false);
+              done();
+            }, 1000);
+          });
+        })
+        .on('error', function(err) {
+          errorCalled = true;
+        })
+        .on('end', function() {
+          console.log('end was called');
+          done();
+        })
+        .saveToFile(testFile);
+  });
+
   describe('Events', function() {
     it('should report codec data through \'codecData\' event', function(done) {
       this.timeout(60000);


### PR DESCRIPTION
If you exit ffmpeg sending it the 'q' key, it will exit with status code 0, but if you send it SIGINT it exits with 255 and if you send it SIGTERM it exits with 147. (from versions of ffmpeg 4.1-4.2)

In all cases it seems to shutdown gracefully, however the second two trigger the 'error' event in fluent-ffmpeg, and when I checked, the error codes from ffmpeg were not documented and not encouraged to be used in scripting.

I added an FfmpegCommand.quit() to gracefully exit by sending the 'q' key to ffmpeg and wrote a unit test to verify it functions. I also verified in my own application this works as expected and does not produce errors.

It would be great if this could be merged and a new version published to npmjs - it seems the current version on the repo lags quite a bit from a lot of bug fixes.