### PR TITLE
fix: filenames emit copy of array

### DIFF
--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -320,7 +320,7 @@ module.exports = function recipes(proto) {
             });
         });
 
-        self.emit('filenames', filenames);
+        self.emit('filenames', [...filenames]);
         next(null, filenames);
       },
 


### PR DESCRIPTION
Changing array of filenames after emit event cause error's like
```
Waiting for the debugger to TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:117:11)
    at Object.join (path.js:375:7)
    at runCommand (...\node_modules\fluent-ffmpeg\lib\recipes.js:391:26)
    at ...\node_modules\async\dist\async.js:473:16
    at next (...\node_modules\async\dist\async.js:5329:29)
    at ...\node_modules\async\dist\async.js:969:16
    at ...\node_modules\fluent-ffmpeg\lib\recipes.js:339:13
    at suppressedCallback (fs.js:210:5)
    at FSReqCallback.oncomplete (fs.js:154:23)
```

Because array is reference type.
This error fixed by emitting copy of source array with filenames