### PR TITLE
fix: eager exiting to prevent hung state

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -241,6 +241,7 @@ module.exports = function(proto) {
       // Handle stdout/stderr streams
       ffprobe.stdout.on('data', function(data) {
         stdout += data;
+        if (parseFfprobeOutput(stdout).duration) ffprobe.kill();
       });
 
       ffprobe.stdout.on('close', function() {
@@ -250,6 +251,7 @@ module.exports = function(proto) {
 
       ffprobe.stderr.on('data', function(data) {
         stderr += data;
+        if (parseFfprobeOutput(stdout).duration) ffprobe.kill();
       });
 
       ffprobe.stderr.on('close', function() {


### PR DESCRIPTION
Possible fix for #1089. I know it's a hacky solution, so not exactly hoping to get merged, but just to show where the problem exists.

It parses the data (`on(data)`) and exists eagerly without having to wait for the exit event - which is what's causing #1089

fixes #1089
