### PR TITLE
Detect hardware accelerated codec and use the correct scale filter

### DIFF
--- a/lib/options/videosize.js
+++ b/lib/options/videosize.js
@@ -6,6 +6,23 @@
  */
 
 
+function getScaleFilter(output) {
+  if (output.video.get('-vcodec').length > 1) {
+    let codec = output.video.get('-vcodec')[1];
+
+    if (codec.endsWith('_vaapi')) {
+      return 'scale_vaapi';
+    }
+    else if (codec.endsWith('_nvenc')) {
+      return 'scale_npp';
+    }
+    else if (codec.endsWith('_qsv')) {
+      return 'scale_qsv';
+    }
+  }
+  return 'scale';
+}
+
 /**
  * Return filters to pad video to width*height,
  *
@@ -69,16 +86,12 @@ function getScalePadFilters(width, height, aspect, color, scale_filter) {
 function createSizeFilters(output, key, value) {
   // Store parameters
   var data = output.sizeData = output.sizeData || {};
-  var scale_filter = "scale";
+  var scale_filter = getScaleFilter(output);
   data[key] = value;
 
   if (!('size' in data)) {
     // No size requested, keep original size
     return [];
-  }
-
-  if (output.video.get('-vcodec').length > 1 && output.video.get('-vcodec')[1].endsWith('_vaapi')) {
-    scale_filter = "scale_vaapi";
   }
 
   // Try to match the different size string formats
@@ -177,7 +190,7 @@ module.exports = function(proto) {
   proto.keepDAR = function() {
     return this.videoFilters([
       {
-        filter: 'scale',
+        filter: getScaleFilter(output),
         options: {
           w: 'if(gt(sar,1),iw*sar,iw)',
           h: 'if(lt(sar,1),ih/sar,ih)'

--- a/lib/options/videosize.js
+++ b/lib/options/videosize.js
@@ -13,10 +13,11 @@
  * @param {Number} height output height
  * @param {Number} aspect video aspect ratio (without padding)
  * @param {Number} color padding color
+ * @param {String} scale_filter scale filter name to use
  * @return scale/pad filters
  * @private
  */
-function getScalePadFilters(width, height, aspect, color) {
+function getScalePadFilters(width, height, aspect, color, scale_filter) {
   /*
     let a be the input aspect ratio, A be the requested aspect ratio
 
@@ -30,7 +31,7 @@ function getScalePadFilters(width, height, aspect, color) {
       When using computed width/height, we truncate them to multiples of 2
      */
     {
-      filter: 'scale',
+      filter: scale_filter,
       options: {
         w: 'if(gt(a,' + aspect + '),' + width + ',trunc(' + height + '*a/2)*2)',
         h: 'if(lt(a,' + aspect + '),' + height + ',trunc(' + width + '/a/2)*2)'
@@ -68,11 +69,16 @@ function getScalePadFilters(width, height, aspect, color) {
 function createSizeFilters(output, key, value) {
   // Store parameters
   var data = output.sizeData = output.sizeData || {};
+  var scale_filter = "scale";
   data[key] = value;
 
   if (!('size' in data)) {
     // No size requested, keep original size
     return [];
+  }
+
+  if (output.video.get('-vcodec').length > 1 && output.video.get('-vcodec')[1].endsWith('_vaapi')) {
+    scale_filter = "scale_vaapi";
   }
 
   // Try to match the different size string formats
@@ -85,7 +91,7 @@ function createSizeFilters(output, key, value) {
   if (percentRatio) {
     var ratio = Number(percentRatio[1]) / 100;
     return [{
-      filter: 'scale',
+      filter: scale_filter,
       options: {
         w: 'trunc(iw*' + ratio + '/2)*2',
         h: 'trunc(ih*' + ratio + '/2)*2'
@@ -99,10 +105,10 @@ function createSizeFilters(output, key, value) {
     aspect = width / height;
 
     if (data.pad) {
-      return getScalePadFilters(width, height, aspect, data.pad);
+      return getScalePadFilters(width, height, aspect, data.pad, scale_filter);
     } else {
       // No autopad requested, rescale to target size
-      return [{ filter: 'scale', options: { w: width, h: height }}];
+      return [{ filter: scale_filter, options: { w: width, h: height }}];
     }
   } else if (fixedWidth || fixedHeight) {
     if ('aspect' in data) {
@@ -115,17 +121,17 @@ function createSizeFilters(output, key, value) {
       height = Math.round(height / 2) * 2;
 
       if (data.pad) {
-        return getScalePadFilters(width, height, data.aspect, data.pad);
+        return getScalePadFilters(width, height, data.aspect, data.pad, scale_filter);
       } else {
         // No autopad requested, rescale to target size
-        return [{ filter: 'scale', options: { w: width, h: height }}];
+        return [{ filter: scale_filter, options: { w: width, h: height }}];
       }
     } else {
       // Keep input aspect ratio
 
       if (fixedWidth) {
         return [{
-          filter: 'scale',
+          filter: scale_filter,
           options: {
             w: Math.round(Number(fixedWidth[1]) / 2) * 2,
             h: 'trunc(ow/a/2)*2'
@@ -133,7 +139,7 @@ function createSizeFilters(output, key, value) {
         }];
       } else {
         return [{
-          filter: 'scale',
+          filter: scale_filter,
           options: {
             w: 'trunc(oh*a/2)*2',
             h: Math.round(Number(fixedHeight[1]) / 2) * 2


### PR DESCRIPTION
Hardware accelerated codec use specific `scale` filters thus `size()` does not generate working video filters.

This PR detects some hardware accelerated video codecs and uses the correct `scale` filter.