### PR TITLE
Prevent numbers in scientific notation from being passed to ffmpeg 

### DIFF
--- a/lib/options/inputs.js
+++ b/lib/options/inputs.js
@@ -147,6 +147,10 @@ module.exports = function(proto) {
       throw new Error('No input specified');
     }
 
+    if (typeof seek === 'number') {
+      seek = utils.formatNumberForCall(seek);
+    }
+
     this._currentInput.options('-ss', seek);
 
     return this;

--- a/lib/options/output.js
+++ b/lib/options/output.js
@@ -88,6 +88,9 @@ module.exports = function(proto) {
    */
   proto.seekOutput =
   proto.seek = function(seek) {
+    if (typeof seek === 'number') {
+      seek = utils.formatNumberForCall(seek);
+    }
     this._currentOutput.options('-ss', seek);
     return this;
   };
@@ -106,6 +109,9 @@ module.exports = function(proto) {
   proto.withDuration =
   proto.setDuration =
   proto.duration = function(duration) {
+    if (typeof duration === 'number') {
+      duration = utils.formatNumberForCall(duration);
+    }
     this._currentOutput.options('-t', duration);
     return this;
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,10 @@ function parseProgressLine(line) {
   return progress;
 }
 
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  useGrouping: false,
+  maximumFractionDigits: 6,
+});
 
 var utils = module.exports = {
   isWindows: isWindows,
@@ -374,7 +378,7 @@ var utils = module.exports = {
    * - close() : prevents further append() calls and does a last call to callbacks
    * - callback(cb) : calls cb for each line (incl. those already in the ring)
    *
-   * @param {Numebr} maxLines maximum number of lines to store (<= 0 for unlimited)
+   * @param {Number} maxLines maximum number of lines to store (<= 0 for unlimited)
    */
   linesRing: function(maxLines) {
     var cbs = [];
@@ -451,5 +455,16 @@ var utils = module.exports = {
         closed = true;
       }
     };
+  },
+
+  /**
+   * Convert number to decimal notation. Javascript floating point numbers are
+   * sometimes represented in scientific notation, and ffmpeg cannot handle
+   * that format.
+   * @param {Number} num number to format for call to ffmpeg
+   * @returns {String} string representation of number in decimal notation
+   */
+  formatNumberForCall: function (num) {
+    return numberFormatter.format(num);
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,8 @@ function parseProgressLine(line) {
 
 const numberFormatter = new Intl.NumberFormat('en-US', {
   useGrouping: false,
-  maximumFractionDigits: 6,
+  // 10 digits to provide ample precision for high samplerate audio
+  maximumFractionDigits: 10,
 });
 
 var utils = module.exports = {

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -432,7 +432,7 @@ describe('Command', function() {
 
           if(args.indexOf('-loop') != -1 || args.indexOf('-loop_output') != -1){
             args.indexOf('-t').should.above(-1);
-            args.indexOf(120).should.above(-1);
+            args.indexOf('120').should.above(-1);
             done();
           }
           else{
@@ -607,6 +607,28 @@ describe('Command', function() {
           done();
         });
     });
+
+    it('should apply start time converted from scientific notation (0)', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .setStartTime(1e-15)
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+          args.indexOf('-ss').should.equal(args.indexOf('0') - 1);
+          done();
+        });
+    });
+
+    it('should apply start time converted from scientific notation (nonzero)', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .setStartTime(1.234567e-9)
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+          args.indexOf('-ss').should.equal(args.indexOf('0.0000000012') - 1);
+          done();
+        });
+    });
   });
 
   describe('setDuration', function() {
@@ -618,7 +640,29 @@ describe('Command', function() {
           assert.ok(!err);
 
           args.indexOf('-t').should.above(-1);
-          args.indexOf(10).should.above(-1);
+          args.indexOf('10').should.above(-1);
+          done();
+        });
+    });
+
+    it('should apply duration converted from scientific notation (0)', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .setDuration(1e-15)
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+          args.indexOf('-t').should.equal(args.indexOf('0') - 1);
+          done();
+        });
+    });
+
+    it('should apply duration converted from scientific notation (nonzero)', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .setDuration(1.234567e-9)
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+          args.indexOf('-t').should.equal(args.indexOf('0.0000000012') - 1);
           done();
         });
     });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -203,4 +203,26 @@ describe('Utilities', function() {
       ring.get().should.equal('foo\nbar\nbazfoo\nbar');
     });
   });
+
+  describe('Format number for call', function() {
+    it('formats decimal notation number as string', function() {
+      utils.formatNumberForCall(0).should.equal('0');
+      utils.formatNumberForCall(1).should.equal('1');
+      utils.formatNumberForCall(1.5).should.equal('1.5');
+      utils.formatNumberForCall(-1.5).should.equal('-1.5');
+    });
+
+    it('truncates numbers to 10 decimal places', function() {
+      utils.formatNumberForCall(234222.2333333333334).should.equal('234222.2333333333');
+      utils.formatNumberForCall(234222.2337777777774).should.equal('234222.2337777778');
+    })
+
+    it('formats scientific notation number as decimal', function() {
+      utils.formatNumberForCall(1e2).should.equal('100');
+      utils.formatNumberForCall(1e-5).should.equal('0.00001');
+      utils.formatNumberForCall(-1e-5).should.equal('-0.00001');
+      utils.formatNumberForCall(5.684341886080802e-14).should.equal('0');
+      utils.formatNumberForCall(-5.684341886080802e-14).should.equal('-0');
+    });
+  })
 });


### PR DESCRIPTION
Calling `seekInput`, `duration`, or `seekOutput` with a number that is represented in js in scientific notation leads to a ffmpeg error:

```js
import ffmpegPath from 'ffmpeg-static';
import ffmpeg from 'fluent-ffmpeg';

ffmpeg.setFfmpegPath(ffmpegPath);

ffmpeg('in.wav')
  .output('out.wav')
  .duration(1e-7)
  .on('error', function(err, stdout, stderr) {
    console.log('An error happened: ' + err.message);
    console.log('ffmpeg standard output:\n' + stdout);
    console.log('ffmpeg standard error:\n' + stderr);
  })
  .run()
```

results in:

```
An error happened: ffmpeg exited with code 1: Invalid duration specification for t: 1e-7

ffmpeg standard output:

ffmpeg standard error:
ffmpeg version 4.3.2-tessus  https://evermeet.cx/ffmpeg/  Copyright (c) 2000-2021 the FFmpeg developers
  built with Apple clang version 11.0.0 (clang-1100.0.33.17)
  configuration: --cc=/usr/bin/clang --prefix=/opt/ffmpeg --extra-version=tessus --enable-avisynth --enable-fontconfig --enable-gpl --enable-libaom --enable-libass --enable-libbluray --enable-libdav1d --enable-libfreetype --enable-libgsm --enable-libmodplug --enable-libmp3lame --enable-libmysofa --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenh264 --enable-libopenjpeg --enable-libopus --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvmaf --enable-libvo-amrwbenc --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxavs --enable-libxvid --enable-libzimg --enable-libzmq --enable-libzvbi --enable-version3 --pkg-config-flags=--static --disable-ffplay
  libavutil      56. 51.100 / 56. 51.100
  libavcodec     58. 91.100 / 58. 91.100
  libavformat    58. 45.100 / 58. 45.100
  libavdevice    58. 10.100 / 58. 10.100
  libavfilter     7. 85.100 /  7. 85.100
  libswscale      5.  7.100 /  5.  7.100
  libswresample   3.  7.100 /  3.  7.100
  libpostproc    55.  7.100 / 55.  7.100
Guessed Channel Layout for Input Stream #0.0 : mono
Input #0, wav, from 'in.wav':
  Metadata:
    originator_reference: aayHNh!eFSVk
    date            : 2021-02-24
    creation_time   : 15:32:33
    time_reference  : 0
    umid            : 0x060A2B340101010501010F1013000000FB1F13F1E785800019E086DAD77A81D0
  Duration: 00:00:03.73, bitrate: 716 kb/s
    Stream #0:0: Audio: pcm_s16le ([1][0][0][0] / 0x0001), 44100 Hz, mono, s16, 705 kb/s
Invalid duration specification for t: 1e-7
```

To prevent this, this PR formats numbers in decimal notation before adding them as ffmpeg arguments.