### PR TITLE
allow readMetadata = false as constructor option to fix issue #930 and #1191

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following options are available:
 * `niceness` or `priority`: ffmpeg niceness value, between -20 and 20; ignored on Windows platforms (defaults to 0)
 * `logger`: logger object with `debug()`, `info()`, `warn()` and `error()` methods (defaults to no logging)
 * `stdoutLines`: maximum number of lines from ffmpeg stdout/stderr to keep in memory (defaults to 100, use 0 for unlimited storage)
+* `readMetadata`: used to disable ffprobe (defaults to true, use false to disable ffprobe)
 
 
 ### Specifying inputs

--- a/lib/fluent-ffmpeg.js
+++ b/lib/fluent-ffmpeg.js
@@ -26,6 +26,7 @@ var ARGLISTS = ['_global', '_audio', '_audioFilters', '_video', '_videoFilters',
  * @param {String} [options.preset="fluent-ffmpeg/lib/presets"] alias for `presets`
  * @param {String} [options.stdoutLines=100] maximum lines of ffmpeg output to keep in memory, use 0 for unlimited
  * @param {Number} [options.timeout=<no timeout>] ffmpeg processing timeout in seconds
+ * @param {Boolean} [options.readMetadata=true] disable ffprob on prepare
  * @param {String|ReadableStream} [options.source=<no input>] alias for the `input` parameter
  */
 function FfmpegCommand(input, options) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -96,6 +96,7 @@ module.exports = function(proto) {
    * - `cwd`: change working directory
    * - 'captureStdout': capture stdout and pass it to 'endCB' as its 2nd argument (default: false)
    * - 'stdoutLines': override command limit (default: use command limit)
+   * - 'readMetadata': disable ffProbe
    *
    * The 'processCB' callback, if present, is called as soon as the process is created and
    * receives a nodejs ChildProcess object.  It may not be called at all if an error happens
@@ -588,7 +589,7 @@ module.exports = function(proto) {
           }
         }
       );
-    });
+    }, self.options.readMetadata || true);
 
     return this;
   };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -285,7 +285,7 @@ module.exports = function(proto) {
    *
    * @method FfmpegCommand#_prepare
    * @param {Function} callback callback with signature (err, args)
-   * @param {Boolean} [readMetadata=false] read metadata before processing
+   * @param {Boolean} [readMetadata=true] read metadata before processing
    * @private
    */
   proto._prepare = function(callback, readMetadata) {
@@ -299,7 +299,7 @@ module.exports = function(proto) {
 
       // Read metadata if required
       function(cb) {
-        if (!readMetadata) {
+        if (readMetadata === false) {
           return cb();
         }
 
@@ -364,7 +364,7 @@ module.exports = function(proto) {
       }
     ], callback);
 
-    if (!readMetadata) {
+    if (readMetadata !== false) {
       // Read metadata as soon as 'progress' listeners are added
 
       if (this.listeners('progress').length > 0) {
@@ -589,7 +589,7 @@ module.exports = function(proto) {
           }
         }
       );
-    }, self.options.readMetadata || true);
+    }, self.options.readMetadata);
 
     return this;
   };


### PR DESCRIPTION
readMetadata = false needs to be used to disable ffprobe from making duplicate calls to url when it is not wanted.