### PR TITLE
[activationBytes] Add support for -activation_bytes option

### DIFF
--- a/lib/options/inputs.js
+++ b/lib/options/inputs.js
@@ -175,4 +175,21 @@ module.exports = function(proto) {
 
     return this;
   };
+
+  /**
+   * Specify activation bytes for the last specified input
+   *
+   * @method FfmpegCommand#activationBytes
+   * @category Input
+   * @param {String} bytes activation bytes
+   * @return FfmpegCommand
+   */
+  proto.activationBytes = function(bytes) {
+    if (!this._currentInput) {
+      throw new Error('No input specified');
+    }
+
+    this._currentInput.options('-activation_bytes', bytes);
+    return this;
+  };
 };

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -1119,4 +1119,21 @@ describe('Command', function() {
       });
     });
   });
+  describe('activationBytes', function() {
+    it('should apply activation bytes to input', function(done) {
+      new Ffmpeg({ source: this.testfile, logger: testhelper.logger })
+        .activationBytes('12345678')
+        ._test_getArgs(function(args, err) {
+          testhelper.logArgError(err);
+          assert.ok(!err);
+  
+          // Check if the '-activation_bytes' option is correctly applied
+          const activationBytesIndex = args.indexOf('-activation_bytes');
+          assert.ok(activationBytesIndex !== -1, 'Activation bytes option not found');
+          assert.strictEqual(args[activationBytesIndex + 1], '12345678', 'Activation bytes value does not match');
+  
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
Assists with conversion of AAX files if the activation bytes are available.
