### PR TITLE
fix parsing of ffmpeg 7 "is a device" formats

### DIFF
--- a/doc/capabilities.js.html
+++ b/doc/capabilities.js.html
@@ -42,7 +42,7 @@ var ffCodecRegexp = /^\s*([D\.])([E\.])([VAS])([I\.])([L\.])([S\.]) ([^ ]+) +(.*
 var ffEncodersRegexp = /\(encoders:([^\)]+)\)/;
 var ffDecodersRegexp = /\(decoders:([^\)]+)\)/;
 var encodersRegexp = /^\s*([VAS\.])([F\.])([S\.])([X\.])([B\.])([D\.]) ([^ ]+) +(.*)$/;
-var formatRegexp = /^\s*([D ])([E ])\s+([^ ]+)\s+(.*)$/;
+var formatRegexp = /^\s*([D ])([E ])[d ]?\s+([^ ]+)\s+(.*)$/;
 var lineBreakRegexp = /\r\n|\r|\n/;
 var filterRegexp = /^(?: [T\.][S\.][C\.] )?([^ ]+) +(AA?|VV?|\|)->(AA?|VV?|\|) +(.*)$/;
 

--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -15,7 +15,7 @@ var ffCodecRegexp = /^\s*([D\.])([E\.])([VAS])([I\.])([L\.])([S\.]) ([^ ]+) +(.*
 var ffEncodersRegexp = /\(encoders:([^\)]+)\)/;
 var ffDecodersRegexp = /\(decoders:([^\)]+)\)/;
 var encodersRegexp = /^\s*([VAS\.])([F\.])([S\.])([X\.])([B\.])([D\.]) ([^ ]+) +(.*)$/;
-var formatRegexp = /^\s*([D ])([E ])\s+([^ ]+)\s+(.*)$/;
+var formatRegexp = /^\s*([D ])([E ])[d ]?\s+([^ ]+)\s+(.*)$/;
 var lineBreakRegexp = /\r\n|\r|\n/;
 var filterRegexp = /^(?: [T\.][S\.][C\.] )?([^ ]+) +(AA?|VV?|\|)->(AA?|VV?|\|) +(.*)$/;
 

--- a/test/capabilities.test.js
+++ b/test/capabilities.test.js
@@ -72,6 +72,14 @@ describe('Capabilities', function() {
         ('canDemux' in formats.wav).should.equal(true);
         (typeof formats.wav.canDemux).should.equal('boolean');
 
+        ('lavfi' in formats).should.equal(true);
+        ('description' in formats.lavfi).should.equal(true);
+        (typeof formats.lavfi.description).should.equal('string');
+        ('canMux' in formats.lavfi).should.equal(true);
+        (typeof formats.lavfi.canMux).should.equal('boolean');
+        ('canDemux' in formats.lavfi).should.equal(true);
+        (typeof formats.lavfi.canDemux).should.equal('boolean');
+
         done();
       });
     });


### PR DESCRIPTION
when running with ffmpeg 7, some formats are not properly parsed by `getAvailableFormats` and thus can not be used.

ffmpeg 7 adds a new column to the output of `-formats` command:
```
..d = Is a device
```

https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/1274 partially addressed that issue, but only for formats where the new column is a space.

Formats that have `d` do not match the existing regex and are silently ignored.

One example is `lavfi` format which right now can not be used due to this issue.

The fix is to ammend the parsing regex to expect an optional space or 'd'. This way both new and old versions of ffmpeg are supported.

I've added a test for `lavfi` which fails without this fix when run with ffmpeg 7.