### PR TITLE
Feat: add missed properties

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -2,8 +2,6 @@
 'use strict';
 
 var spawn = require('child_process').spawn;
-var path = require('path');
-var fs = require('fs');
 var async = require('async');
 var utils = require('./utils');
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -66,6 +66,7 @@ module.exports = function(proto) {
    * @param {String} codecData.audio_details input audio codec parameters
    * @param {String} codecData.video input video codec name
    * @param {String} codecData.video_details input video codec parameters
+   * @param {String} codecData.duration input video duration
    */
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -294,7 +294,7 @@ var utils = module.exports = {
       inInput = codecsObject.inInput = true;
       inputIndex = codecsObject.inputIndex = codecsObject.inputIndex + 1;
 
-      inputStack[inputIndex] = { format: format[1], audio: '', video: '', duration: '' };
+      inputStack[inputIndex] = { format: format[1], audio: '', audio_details: '', video: '', duration: '' };
     } else if (inInput && (dur = stderrLine.match(durPattern))) {
       inputStack[inputIndex].duration = dur[1];
     } else if (inInput && (audio = stderrLine.match(audioPattern))) {


### PR DESCRIPTION
## When uploading a video without audio, the 'data' parameter passed to the callback function in the codecData event is as follows.

```javascript
const command = Ffmpeg(inputFilePath)
    .setFfmpegPath(ffmpegInstall.path)
    .outputOptions([
   '-profile:v baseline',
   '-level 3.0',
   '-start_number 0',
   '-hls_time 10',
   '-hls_list_size 0',
   '-f hls',
]);

command.on('codecData', (data) => {
   console.log('codecData: ', data);
});
```
```shell
# Output Result

codecData:  {
  format: 'mov,mp4,m4a,3gp,3g2,mj2',
  audio: '',
  video: 'h264 (Constrained Baseline) (avc1 / 0x31637661)',
  duration: '00:00:05.00',
  video_details: [
    'h264 (Constrained Baseline) (avc1 / 0x31637661)',
    'yuv420p',
    '600x336 [SAR 1:1 DAR 25:14]',
    '127 kb/s',
    '10 fps',
    '10 tbr',
    '10240 tbn',
    '20 tbc (default)'
  ]
}
```
As shown in the example above, the 'audio' property is initialized as an empty string. However, upon examining the original code, we notice an inconsistency: while the 'audio' property is initialized with an empty string, the 'audio_details' property is not initialized at all. This situation presents two issues:

1. Lack of code consistency: The 'audio' property is initialized, but 'audio_details' is not.
2. Discrepancy with @types/fluent-ffmpeg: In the type definitions of @types/fluent-ffmpeg, 'audio_details' is defined as a required string, not an optional one.

These inconsistencies can lead to confusion among developers and may cause unexpected errors during type checking. Furthermore, it creates a mismatch between the actual implementation and the type definitions, potentially leading to runtime errors that are not caught during development.

### Therefore, I have added an initialization statement for audio_details as follows
```javascript
inputStack[inputIndex] = { format: format[1], audio: '', audio_details: '', video: '', duration: '' };
```


## Remove unused varibales
```javascript
var path = require('path');
var fs = require('fs');
```

## Update JSDoc property an codecData#duration
```javascript
@param {String} codecData.duration input video duration
```