### PR TITLE
Add coverage and .vscode directories to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@
 .git*
 test/
 examples/
+coverage/
+.vscode/


### PR DESCRIPTION
This PR adds the coverage directory to the .npmignore file. Currently, the published package includes the coverage directory, resulting in an unnecessarily large package size (~12MB). By ignoring this directory, we ensure the package remains lightweight and focused, improving installation efficiency for users.

Let me know if there's anything else you'd like me to include!
<img width="888" alt="image" src="https://github.com/user-attachments/assets/0e4ec524-d0a1-420a-84e4-9d3d3f332634">
