### PR TITLE
fix: fix for using input options in ffprobe

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -152,7 +152,7 @@ module.exports = function(proto) {
 
       // Spawn ffprobe
       var src = input.isStream ? 'pipe:0' : input.source;
-      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(options, src), {windowsHide: true});
+      var ffprobe = spawn(path, ['-show_streams', '-show_format'].concat(input.options.get(), options, src), {windowsHide: true});
 
       if (input.isStream) {
         // Skip errors on stdin. These get thrown when ffprobe is complete and


### PR DESCRIPTION
Input options are currently not passed through to ffprobe. This can be a problem if a URL requires authorization headers. Without the fix ffmepg uses the authorisation headers but ffprobe doesn't. 

For example, to have percentages in a `progress` object, the library uses ffprobe. If the file is protected with authorization, ffprobe couldn't get a file and therefore not report the progress.

Fixes issue #1146  